### PR TITLE
refactor(DEEP-209): Improve Kafka message acknowledgment logic

### DIFF
--- a/src/main/java/uk/gov/companieshouse/chs/notification/kafka/consumer/apiintegration/ApiIntegrationImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chs/notification/kafka/consumer/apiintegration/ApiIntegrationImpl.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.chs.notification.kafka.consumer.apiintegration;
 
-import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
@@ -11,7 +10,6 @@ import static uk.gov.companieshouse.chs.notification.kafka.consumer.utils.Static
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 
-
 @Service
 class ApiIntegrationImpl implements ApiIntegrationInterface {
 
@@ -19,13 +17,13 @@ class ApiIntegrationImpl implements ApiIntegrationInterface {
 
     private static final Logger LOG = LoggerFactory.getLogger(APPLICATION_NAMESPACE);
 
-    public ApiIntegrationImpl( final WebClient integrationWebClient) {
+    public ApiIntegrationImpl(final WebClient integrationWebClient) {
         this.integrationWebClient = integrationWebClient;
     }
 
     @Override
     public void sendEmailMessageToIntegrationApi(final GovUkEmailDetailsRequest govUkEmailDetailsRequest,
-                                                 final Acknowledgment acknowledgment) {
+                                                 final Runnable onSuccess) {
         integrationWebClient.post()
                 .uri("/chs-gov-uk-notify-integration-api/email")
                 .header("Content-Type", "application/json")
@@ -33,7 +31,7 @@ class ApiIntegrationImpl implements ApiIntegrationInterface {
                 .exchangeToMono(response -> {
                     if (response.statusCode().is2xxSuccessful()) {
                         LOG.info("Successfully sent email request to integration API, status: " + response.statusCode());
-                        acknowledgment.acknowledge();
+                        onSuccess.run();
                         return Mono.empty();
                     } else {
                         LOG.error("Failed to send email request to integration API, status: " + response.statusCode());
@@ -49,7 +47,7 @@ class ApiIntegrationImpl implements ApiIntegrationInterface {
 
     @Override
     public void sendLetterMessageToIntegrationApi(final GovUkLetterDetailsRequest govUkLetterDetailsRequest,
-                                                  final Acknowledgment acknowledgment) {
+                                                  final Runnable onSuccess) {
         integrationWebClient.post()
                 .uri("/chs-gov-uk-notify-integration-api/letter")
                 .header("Content-Type", "application/json")
@@ -57,7 +55,7 @@ class ApiIntegrationImpl implements ApiIntegrationInterface {
                 .exchangeToMono(response -> {
                     if (response.statusCode().is2xxSuccessful()) {
                         LOG.info("Successfully sent letter request to integration API, status: " + response.statusCode());
-                        acknowledgment.acknowledge();
+                        onSuccess.run();
                         return Mono.empty();
                     } else {
                         LOG.error("Failed to send letter request to integration API, status: " + response.statusCode());
@@ -71,4 +69,3 @@ class ApiIntegrationImpl implements ApiIntegrationInterface {
                 .subscribe();
     }
 }
-

--- a/src/main/java/uk/gov/companieshouse/chs/notification/kafka/consumer/apiintegration/ApiIntegrationImpl.java
+++ b/src/main/java/uk/gov/companieshouse/chs/notification/kafka/consumer/apiintegration/ApiIntegrationImpl.java
@@ -28,18 +28,14 @@ class ApiIntegrationImpl implements ApiIntegrationInterface {
                 .uri("/chs-gov-uk-notify-integration-api/email")
                 .header("Content-Type", "application/json")
                 .bodyValue(govUkEmailDetailsRequest)
-                .exchangeToMono(response -> {
-                    if (response.statusCode().is2xxSuccessful()) {
-                        LOG.info("Successfully sent email request to integration API, status: " + response.statusCode());
-                        onSuccess.run();
-                        return Mono.empty();
-                    } else {
-                        LOG.error("Failed to send email request to integration API, status: " + response.statusCode());
-                        return Mono.error(new RuntimeException("API call failed with status: " + response.statusCode()));
-                    }
+                .retrieve()
+                .toBodilessEntity()
+                .doOnSuccess(response -> {
+                    LOG.info("Successfully sent email request to integration API");
+                    onSuccess.run();
                 })
                 .onErrorResume(e -> {
-                    LOG.error("Exception when sending email request to integration API: " + e.getMessage());
+                    LOG.error("Failed to send email request to integration API: " + e.getMessage());
                     return Mono.empty();
                 })
                 .subscribe();
@@ -52,18 +48,14 @@ class ApiIntegrationImpl implements ApiIntegrationInterface {
                 .uri("/chs-gov-uk-notify-integration-api/letter")
                 .header("Content-Type", "application/json")
                 .bodyValue(govUkLetterDetailsRequest)
-                .exchangeToMono(response -> {
-                    if (response.statusCode().is2xxSuccessful()) {
-                        LOG.info("Successfully sent letter request to integration API, status: " + response.statusCode());
-                        onSuccess.run();
-                        return Mono.empty();
-                    } else {
-                        LOG.error("Failed to send letter request to integration API, status: " + response.statusCode());
-                        return Mono.error(new RuntimeException("API call failed with status: " + response.statusCode()));
-                    }
+                .retrieve()
+                .toBodilessEntity()
+                .doOnSuccess(response -> {
+                    LOG.info("Successfully sent letter request to integration API");
+                    onSuccess.run();
                 })
                 .onErrorResume(e -> {
-                    LOG.error("Exception when sending letter request to integration API: " + e.getMessage());
+                    LOG.error("Failed to send letter request to integration API: " + e.getMessage());
                     return Mono.empty();
                 })
                 .subscribe();

--- a/src/main/java/uk/gov/companieshouse/chs/notification/kafka/consumer/apiintegration/ApiIntegrationInterface.java
+++ b/src/main/java/uk/gov/companieshouse/chs/notification/kafka/consumer/apiintegration/ApiIntegrationInterface.java
@@ -1,7 +1,6 @@
 package uk.gov.companieshouse.chs.notification.kafka.consumer.apiintegration;
 
 import jakarta.validation.constraints.NotNull;
-import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
 import uk.gov.companieshouse.api.chs_notification_sender.model.GovUkEmailDetailsRequest;
@@ -11,7 +10,7 @@ import uk.gov.companieshouse.api.chs_notification_sender.model.GovUkLetterDetail
 @Component
 public interface ApiIntegrationInterface {
 
-     void sendEmailMessageToIntegrationApi(@NotNull GovUkEmailDetailsRequest govUkEmailDetailsRequest, @NotNull Acknowledgment acknowledgment);
+     void sendEmailMessageToIntegrationApi(@NotNull GovUkEmailDetailsRequest govUkEmailDetailsRequest, @NotNull Runnable onSuccess);
 
-     void sendLetterMessageToIntegrationApi(@NotNull GovUkLetterDetailsRequest govUkLetterRequest, @NotNull Acknowledgment acknowledgment);
+     void sendLetterMessageToIntegrationApi(@NotNull GovUkLetterDetailsRequest govUkLetterRequest, @NotNull Runnable onSuccess);
 }

--- a/src/main/java/uk/gov/companieshouse/chs/notification/kafka/consumer/apiintegration/ApiIntegrationInterface.java
+++ b/src/main/java/uk/gov/companieshouse/chs/notification/kafka/consumer/apiintegration/ApiIntegrationInterface.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.chs.notification.kafka.consumer.apiintegration;
 
 import jakarta.validation.constraints.NotNull;
+import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
 import uk.gov.companieshouse.api.chs_notification_sender.model.GovUkEmailDetailsRequest;
@@ -10,7 +11,7 @@ import uk.gov.companieshouse.api.chs_notification_sender.model.GovUkLetterDetail
 @Component
 public interface ApiIntegrationInterface {
 
-     void sendEmailMessageToIntegrationApi(@NotNull GovUkEmailDetailsRequest govUkEmailDetailsRequest);
+     void sendEmailMessageToIntegrationApi(@NotNull GovUkEmailDetailsRequest govUkEmailDetailsRequest, @NotNull Acknowledgment acknowledgment);
 
-     void sendLetterMessageToIntegrationApi(@NotNull GovUkLetterDetailsRequest govUkLetterRequest);
+     void sendLetterMessageToIntegrationApi(@NotNull GovUkLetterDetailsRequest govUkLetterRequest, @NotNull Acknowledgment acknowledgment);
 }

--- a/src/main/java/uk/gov/companieshouse/chs/notification/kafka/consumer/kafkaintegration/KafkaConsumerService.java
+++ b/src/main/java/uk/gov/companieshouse/chs/notification/kafka/consumer/kafkaintegration/KafkaConsumerService.java
@@ -42,8 +42,7 @@ class KafkaConsumerService {
     public void consumeEmailMessage(ConsumerRecord<String, byte[]> record, Acknowledgment acknowledgment) {
         if(record !=null && record.value() !=null && record.value().length !=0) {
             final var emailRequest = kafkaTranslatorInterface.translateEmailKafkaMessage(record.value());
-            apiIntegrationInterface.sendEmailMessageToIntegrationApi(emailRequest);
-            acknowledgment.acknowledge();
+            apiIntegrationInterface.sendEmailMessageToIntegrationApi(emailRequest, acknowledgment);
         } else {
             throw new IllegalArgumentException("Received null or empty Email message");
         }
@@ -67,8 +66,7 @@ class KafkaConsumerService {
     public void consumeLetterMessage(ConsumerRecord<String, byte[]> record, Acknowledgment acknowledgment) {
         if(record !=null && record.value() !=null && record.value().length !=0) {
             final var letterRequest = kafkaTranslatorInterface.translateLetterKafkaMessage(record.value());
-            apiIntegrationInterface.sendLetterMessageToIntegrationApi(letterRequest);
-            acknowledgment.acknowledge();
+            apiIntegrationInterface.sendLetterMessageToIntegrationApi(letterRequest, acknowledgment);
         } else {
             throw new IllegalArgumentException("Received null or empty Letter message");
         }

--- a/src/main/java/uk/gov/companieshouse/chs/notification/kafka/consumer/kafkaintegration/KafkaConsumerService.java
+++ b/src/main/java/uk/gov/companieshouse/chs/notification/kafka/consumer/kafkaintegration/KafkaConsumerService.java
@@ -42,7 +42,7 @@ class KafkaConsumerService {
     public void consumeEmailMessage(ConsumerRecord<String, byte[]> record, Acknowledgment acknowledgment) {
         if(record !=null && record.value() !=null && record.value().length !=0) {
             final var emailRequest = kafkaTranslatorInterface.translateEmailKafkaMessage(record.value());
-            apiIntegrationInterface.sendEmailMessageToIntegrationApi(emailRequest, acknowledgment);
+            apiIntegrationInterface.sendEmailMessageToIntegrationApi(emailRequest, acknowledgment::acknowledge);
         } else {
             throw new IllegalArgumentException("Received null or empty Email message");
         }
@@ -66,7 +66,7 @@ class KafkaConsumerService {
     public void consumeLetterMessage(ConsumerRecord<String, byte[]> record, Acknowledgment acknowledgment) {
         if(record !=null && record.value() !=null && record.value().length !=0) {
             final var letterRequest = kafkaTranslatorInterface.translateLetterKafkaMessage(record.value());
-            apiIntegrationInterface.sendLetterMessageToIntegrationApi(letterRequest, acknowledgment);
+            apiIntegrationInterface.sendLetterMessageToIntegrationApi(letterRequest, acknowledgment::acknowledge);
         } else {
             throw new IllegalArgumentException("Received null or empty Letter message");
         }

--- a/src/test/java/uk/gov/companieshouse/chs/notification/kafka/consumer/apiintegration/ApiIntegrationImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/notification/kafka/consumer/apiintegration/ApiIntegrationImplTest.java
@@ -61,7 +61,7 @@ class ApiIntegrationImplTest {
         when(requestHeadersSpec.exchangeToMono(functionCaptor.capture()))
                 .thenReturn(Mono.empty());
 
-        apiIntegrationImpl.sendEmailMessageToIntegrationApi(govUkEmailDetailsRequest, acknowledgment);
+        apiIntegrationImpl.sendEmailMessageToIntegrationApi(govUkEmailDetailsRequest, acknowledgment::acknowledge);
 
         verify(requestBodySpec).bodyValue(govUkEmailDetailsRequest);
         verify(requestBodyUriSpec).uri("/chs-gov-uk-notify-integration-api/email");
@@ -86,7 +86,7 @@ class ApiIntegrationImplTest {
         when(requestHeadersSpec.exchangeToMono(functionCaptor.capture()))
                 .thenReturn(Mono.empty());
 
-        apiIntegrationImpl.sendEmailMessageToIntegrationApi(govUkEmailDetailsRequest, acknowledgment);
+        apiIntegrationImpl.sendEmailMessageToIntegrationApi(govUkEmailDetailsRequest, acknowledgment::acknowledge);
 
         verify(requestBodySpec).bodyValue(govUkEmailDetailsRequest);
         verify(requestBodyUriSpec).uri("/chs-gov-uk-notify-integration-api/email");
@@ -111,7 +111,7 @@ class ApiIntegrationImplTest {
         when(requestHeadersSpec.exchangeToMono(functionCaptor.capture()))
                 .thenReturn(Mono.empty());
 
-        apiIntegrationImpl.sendLetterMessageToIntegrationApi(govUkLetterDetailsRequest, acknowledgment);
+        apiIntegrationImpl.sendLetterMessageToIntegrationApi(govUkLetterDetailsRequest, acknowledgment::acknowledge);
 
         verify(requestBodySpec).bodyValue(govUkLetterDetailsRequest);
         verify(requestBodyUriSpec).uri("/chs-gov-uk-notify-integration-api/letter");
@@ -136,7 +136,7 @@ class ApiIntegrationImplTest {
         when(requestHeadersSpec.exchangeToMono(functionCaptor.capture()))
                 .thenReturn(Mono.empty());
 
-        apiIntegrationImpl.sendLetterMessageToIntegrationApi(govUkLetterDetailsRequest, acknowledgment);
+        apiIntegrationImpl.sendLetterMessageToIntegrationApi(govUkLetterDetailsRequest, acknowledgment::acknowledge);
 
         verify(requestBodySpec).bodyValue(govUkLetterDetailsRequest);
         verify(requestBodyUriSpec).uri("/chs-gov-uk-notify-integration-api/letter");

--- a/src/test/java/uk/gov/companieshouse/chs/notification/kafka/consumer/apiintegration/ApiIntegrationImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/notification/kafka/consumer/apiintegration/ApiIntegrationImplTest.java
@@ -7,7 +7,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 import uk.gov.companieshouse.api.chs_notification_sender.model.GovUkEmailDetailsRequest;
@@ -36,7 +35,7 @@ class ApiIntegrationImplTest {
     private WebClient.ResponseSpec responseSpec;
 
     @Mock
-    private Acknowledgment acknowledgment;
+    private Runnable callback;
 
     @InjectMocks
     private ApiIntegrationImpl apiIntegrationImpl;
@@ -53,7 +52,7 @@ class ApiIntegrationImplTest {
         Mockito.doReturn(responseSpec).when(requestHeadersSpec).retrieve();
         Mockito.doReturn(Mono.just(responseEntity)).when(responseSpec).toBodilessEntity();
 
-        apiIntegrationImpl.sendEmailMessageToIntegrationApi(govUkEmailDetailsRequest, acknowledgment::acknowledge);
+        apiIntegrationImpl.sendEmailMessageToIntegrationApi(govUkEmailDetailsRequest, callback);
 
         verify(requestBodySpec).bodyValue(govUkEmailDetailsRequest);
         verify(requestBodyUriSpec).uri("/chs-gov-uk-notify-integration-api/email");
@@ -72,13 +71,13 @@ class ApiIntegrationImplTest {
         Mockito.doReturn(responseSpec).when(requestHeadersSpec).retrieve();
         Mockito.doReturn(Mono.error(new RuntimeException("Error"))).when(responseSpec).toBodilessEntity();
 
-        apiIntegrationImpl.sendEmailMessageToIntegrationApi(govUkEmailDetailsRequest, acknowledgment::acknowledge);
+        apiIntegrationImpl.sendEmailMessageToIntegrationApi(govUkEmailDetailsRequest, callback);
 
         verify(requestBodySpec).bodyValue(govUkEmailDetailsRequest);
         verify(requestBodyUriSpec).uri("/chs-gov-uk-notify-integration-api/email");
         verify(requestHeadersSpec).retrieve();
         verify(responseSpec).toBodilessEntity();
-        verify(acknowledgment, never()).acknowledge();
+        verify(callback, never()).run();
     }
 
     @Test
@@ -93,7 +92,7 @@ class ApiIntegrationImplTest {
         Mockito.doReturn(responseSpec).when(requestHeadersSpec).retrieve();
         Mockito.doReturn(Mono.just(responseEntity)).when(responseSpec).toBodilessEntity();
 
-        apiIntegrationImpl.sendLetterMessageToIntegrationApi(govUkLetterDetailsRequest, acknowledgment::acknowledge);
+        apiIntegrationImpl.sendLetterMessageToIntegrationApi(govUkLetterDetailsRequest, callback);
 
         verify(requestBodySpec).bodyValue(govUkLetterDetailsRequest);
         verify(requestBodyUriSpec).uri("/chs-gov-uk-notify-integration-api/letter");
@@ -112,12 +111,12 @@ class ApiIntegrationImplTest {
         Mockito.doReturn(responseSpec).when(requestHeadersSpec).retrieve();
         Mockito.doReturn(Mono.error(new RuntimeException("Error"))).when(responseSpec).toBodilessEntity();
 
-        apiIntegrationImpl.sendLetterMessageToIntegrationApi(govUkLetterDetailsRequest, acknowledgment::acknowledge);
+        apiIntegrationImpl.sendLetterMessageToIntegrationApi(govUkLetterDetailsRequest, callback);
 
         verify(requestBodySpec).bodyValue(govUkLetterDetailsRequest);
         verify(requestBodyUriSpec).uri("/chs-gov-uk-notify-integration-api/letter");
         verify(requestHeadersSpec).retrieve();
         verify(responseSpec).toBodilessEntity();
-        verify(acknowledgment, never()).acknowledge();
+        verify(callback, never()).run();
     }
 }

--- a/src/test/java/uk/gov/companieshouse/chs/notification/kafka/consumer/apiintegration/ApiIntegrationImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/notification/kafka/consumer/apiintegration/ApiIntegrationImplTest.java
@@ -5,6 +5,7 @@ import java.util.function.Function;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -54,15 +55,18 @@ class ApiIntegrationImplTest {
         Mockito.doReturn(requestHeadersSpec).when(requestBodySpec).bodyValue(govUkEmailDetailsRequest);
 
         when(clientResponse.statusCode()).thenReturn(HttpStatus.OK);
-        when(requestHeadersSpec.exchangeToMono(any())).thenAnswer(invocation -> {
-            var function = invocation.getArgument(0);
-            return ((java.util.function.Function<ClientResponse, Mono<Void>>) function).apply(clientResponse);
-        });
+
+        ArgumentCaptor<Function<ClientResponse, Mono<Void>>> functionCaptor =
+                ArgumentCaptor.forClass(Function.class);
+        when(requestHeadersSpec.exchangeToMono(functionCaptor.capture()))
+                .thenReturn(Mono.empty());
 
         apiIntegrationImpl.sendEmailMessageToIntegrationApi(govUkEmailDetailsRequest, acknowledgment);
 
         verify(requestBodySpec).bodyValue(govUkEmailDetailsRequest);
         verify(requestBodyUriSpec).uri("/chs-gov-uk-notify-integration-api/email");
+
+        functionCaptor.getValue().apply(clientResponse);
         verify(acknowledgment).acknowledge();
     }
 
@@ -76,15 +80,18 @@ class ApiIntegrationImplTest {
         Mockito.doReturn(requestHeadersSpec).when(requestBodySpec).bodyValue(govUkEmailDetailsRequest);
 
         when(clientResponse.statusCode()).thenReturn(HttpStatus.INTERNAL_SERVER_ERROR);
-        when(requestHeadersSpec.exchangeToMono(any())).thenAnswer(invocation -> {
-            var function = invocation.getArgument(0);
-            return ((Function<ClientResponse, Mono<Void>>) function).apply(clientResponse);
-        });
+
+        ArgumentCaptor<Function<ClientResponse, Mono<Void>>> functionCaptor =
+                ArgumentCaptor.forClass(Function.class);
+        when(requestHeadersSpec.exchangeToMono(functionCaptor.capture()))
+                .thenReturn(Mono.empty());
 
         apiIntegrationImpl.sendEmailMessageToIntegrationApi(govUkEmailDetailsRequest, acknowledgment);
 
         verify(requestBodySpec).bodyValue(govUkEmailDetailsRequest);
         verify(requestBodyUriSpec).uri("/chs-gov-uk-notify-integration-api/email");
+
+        functionCaptor.getValue().apply(clientResponse);
         verify(acknowledgment, never()).acknowledge();
     }
 
@@ -98,15 +105,18 @@ class ApiIntegrationImplTest {
         Mockito.doReturn(requestHeadersSpec).when(requestBodySpec).bodyValue(govUkLetterDetailsRequest);
 
         when(clientResponse.statusCode()).thenReturn(HttpStatus.OK);
-        when(requestHeadersSpec.exchangeToMono(any())).thenAnswer(invocation -> {
-            var function = invocation.getArgument(0);
-            return ((Function<ClientResponse, Mono<Void>>) function).apply(clientResponse);
-        });
+
+        ArgumentCaptor<Function<ClientResponse, Mono<Void>>> functionCaptor =
+                ArgumentCaptor.forClass(Function.class);
+        when(requestHeadersSpec.exchangeToMono(functionCaptor.capture()))
+                .thenReturn(Mono.empty());
 
         apiIntegrationImpl.sendLetterMessageToIntegrationApi(govUkLetterDetailsRequest, acknowledgment);
 
         verify(requestBodySpec).bodyValue(govUkLetterDetailsRequest);
         verify(requestBodyUriSpec).uri("/chs-gov-uk-notify-integration-api/letter");
+
+        functionCaptor.getValue().apply(clientResponse);
         verify(acknowledgment).acknowledge();
     }
 
@@ -120,15 +130,18 @@ class ApiIntegrationImplTest {
         Mockito.doReturn(requestHeadersSpec).when(requestBodySpec).bodyValue(govUkLetterDetailsRequest);
 
         when(clientResponse.statusCode()).thenReturn(HttpStatus.INTERNAL_SERVER_ERROR);
-        when(requestHeadersSpec.exchangeToMono(any())).thenAnswer(invocation -> {
-            var function = invocation.getArgument(0);
-            return ((Function<ClientResponse, Mono<Void>>) function).apply(clientResponse);
-        });
+
+        ArgumentCaptor<Function<ClientResponse, Mono<Void>>> functionCaptor =
+                ArgumentCaptor.forClass(Function.class);
+        when(requestHeadersSpec.exchangeToMono(functionCaptor.capture()))
+                .thenReturn(Mono.empty());
 
         apiIntegrationImpl.sendLetterMessageToIntegrationApi(govUkLetterDetailsRequest, acknowledgment);
 
         verify(requestBodySpec).bodyValue(govUkLetterDetailsRequest);
         verify(requestBodyUriSpec).uri("/chs-gov-uk-notify-integration-api/letter");
+
+        functionCaptor.getValue().apply(clientResponse);
         verify(acknowledgment, never()).acknowledge();
     }
 }

--- a/src/test/java/uk/gov/companieshouse/chs/notification/kafka/consumer/apiintegration/ApiIntegrationInterfaceTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/notification/kafka/consumer/apiintegration/ApiIntegrationInterfaceTest.java
@@ -33,7 +33,7 @@ public class ApiIntegrationInterfaceTest {
     })
     public void When_EmailRequestAndAcknowledgmentCombinations_Expect_ExceptionToBeThrown(String requestState, String ackState) {
         GovUkEmailDetailsRequest request = "IsNull".equals(requestState) ? null : new GovUkEmailDetailsRequest();
-        Acknowledgment ack = "IsNull".equals(ackState) ? null : acknowledgment;
+        Runnable ack = "IsNull".equals(ackState) ? null : acknowledgment::acknowledge;
 
         assertThrows(ConstraintViolationException.class, () -> {
             apiIntegration.sendEmailMessageToIntegrationApi(request, ack);
@@ -48,7 +48,7 @@ public class ApiIntegrationInterfaceTest {
     })
     public void When_LetterRequestAndAcknowledgmentCombinations_Expect_ExceptionToBeThrown(String requestState, String ackState) {
         GovUkLetterDetailsRequest request = "IsNull".equals(requestState) ? null : new GovUkLetterDetailsRequest();
-        Acknowledgment ack = "IsNull".equals(ackState) ? null : acknowledgment;
+        Runnable ack = "IsNull".equals(ackState) ? null : acknowledgment::acknowledge;
 
         assertThrows(ConstraintViolationException.class, () -> {
             apiIntegration.sendLetterMessageToIntegrationApi(request, ack);

--- a/src/test/java/uk/gov/companieshouse/chs/notification/kafka/consumer/apiintegration/ApiIntegrationInterfaceTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/notification/kafka/consumer/apiintegration/ApiIntegrationInterfaceTest.java
@@ -4,11 +4,9 @@ import jakarta.validation.ConstraintViolationException;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.kafka.support.Acknowledgment;
 import uk.gov.companieshouse.api.chs_notification_sender.model.GovUkEmailDetailsRequest;
 import uk.gov.companieshouse.api.chs_notification_sender.model.GovUkLetterDetailsRequest;
 
@@ -22,36 +20,33 @@ public class ApiIntegrationInterfaceTest {
     @Qualifier("apiIntegrationImpl")
     private ApiIntegrationInterface apiIntegration;
 
-    @Mock
-    private Acknowledgment acknowledgment;
-
-    @ParameterizedTest(name = "When_EmailRequest{0}_And_Acknowledgment{1}_Expect_ExceptionToBeThrown")
+    @ParameterizedTest(name = "When email request is {0} and callback is {1}, exception should be thrown")
     @CsvSource({
-            "IsNull, IsValid",
-            "IsNull, IsNull",
-            "IsValid, IsNull"
+            "null, valid",
+            "null, null",
+            "valid, null"
     })
-    public void When_EmailRequestAndAcknowledgmentCombinations_Expect_ExceptionToBeThrown(String requestState, String ackState) {
-        GovUkEmailDetailsRequest request = "IsNull".equals(requestState) ? null : new GovUkEmailDetailsRequest();
-        Runnable ack = "IsNull".equals(ackState) ? null : acknowledgment::acknowledge;
+    public void testEmailRequestValidation(String requestState, String callbackState) {
+        GovUkEmailDetailsRequest request = "null".equals(requestState) ? null : new GovUkEmailDetailsRequest();
+        Runnable callback = "null".equals(callbackState) ? null : () -> {};
 
-        assertThrows(ConstraintViolationException.class, () -> {
-            apiIntegration.sendEmailMessageToIntegrationApi(request, ack);
-        });
+        assertThrows(ConstraintViolationException.class, () ->
+                apiIntegration.sendEmailMessageToIntegrationApi(request, callback)
+        );
     }
 
-    @ParameterizedTest(name = "When_LetterRequest{0}_And_Acknowledgment{1}_Expect_ExceptionToBeThrown")
+    @ParameterizedTest(name = "When letter request is {0} and callback is {1}, exception should be thrown")
     @CsvSource({
-            "IsNull, IsValid",
-            "IsNull, IsNull",
-            "IsValid, IsNull"
+            "null, valid",
+            "null, null",
+            "valid, null"
     })
-    public void When_LetterRequestAndAcknowledgmentCombinations_Expect_ExceptionToBeThrown(String requestState, String ackState) {
-        GovUkLetterDetailsRequest request = "IsNull".equals(requestState) ? null : new GovUkLetterDetailsRequest();
-        Runnable ack = "IsNull".equals(ackState) ? null : acknowledgment::acknowledge;
+    public void testLetterRequestValidation(String requestState, String callbackState) {
+        GovUkLetterDetailsRequest request = "null".equals(requestState) ? null : new GovUkLetterDetailsRequest();
+        Runnable callback = "null".equals(callbackState) ? null : () -> {};
 
-        assertThrows(ConstraintViolationException.class, () -> {
-            apiIntegration.sendLetterMessageToIntegrationApi(request, ack);
-        });
+        assertThrows(ConstraintViolationException.class, () ->
+                apiIntegration.sendLetterMessageToIntegrationApi(request, callback)
+        );
     }
 }

--- a/src/test/java/uk/gov/companieshouse/chs/notification/kafka/consumer/apiintegration/ApiIntegrationInterfaceTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/notification/kafka/consumer/apiintegration/ApiIntegrationInterfaceTest.java
@@ -1,0 +1,57 @@
+package uk.gov.companieshouse.chs.notification.kafka.consumer.apiintegration;
+
+import jakarta.validation.ConstraintViolationException;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.support.Acknowledgment;
+import uk.gov.companieshouse.api.chs_notification_sender.model.GovUkEmailDetailsRequest;
+import uk.gov.companieshouse.api.chs_notification_sender.model.GovUkLetterDetailsRequest;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+@Tag("unit-test")
+public class ApiIntegrationInterfaceTest {
+
+    @Autowired
+    @Qualifier("apiIntegrationImpl")
+    private ApiIntegrationInterface apiIntegration;
+
+    @Mock
+    private Acknowledgment acknowledgment;
+
+    @ParameterizedTest(name = "When_EmailRequest{0}_And_Acknowledgment{1}_Expect_ExceptionToBeThrown")
+    @CsvSource({
+            "IsNull, IsValid",
+            "IsNull, IsNull",
+            "IsValid, IsNull"
+    })
+    public void When_EmailRequestAndAcknowledgmentCombinations_Expect_ExceptionToBeThrown(String requestState, String ackState) {
+        GovUkEmailDetailsRequest request = "IsNull".equals(requestState) ? null : new GovUkEmailDetailsRequest();
+        Acknowledgment ack = "IsNull".equals(ackState) ? null : acknowledgment;
+
+        assertThrows(ConstraintViolationException.class, () -> {
+            apiIntegration.sendEmailMessageToIntegrationApi(request, ack);
+        });
+    }
+
+    @ParameterizedTest(name = "When_LetterRequest{0}_And_Acknowledgment{1}_Expect_ExceptionToBeThrown")
+    @CsvSource({
+            "IsNull, IsValid",
+            "IsNull, IsNull",
+            "IsValid, IsNull"
+    })
+    public void When_LetterRequestAndAcknowledgmentCombinations_Expect_ExceptionToBeThrown(String requestState, String ackState) {
+        GovUkLetterDetailsRequest request = "IsNull".equals(requestState) ? null : new GovUkLetterDetailsRequest();
+        Acknowledgment ack = "IsNull".equals(ackState) ? null : acknowledgment;
+
+        assertThrows(ConstraintViolationException.class, () -> {
+            apiIntegration.sendLetterMessageToIntegrationApi(request, ack);
+        });
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/chs/notification/kafka/consumer/kafkaintegration/KafkaConsumerServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/notification/kafka/consumer/kafkaintegration/KafkaConsumerServiceTest.java
@@ -68,7 +68,6 @@ public class KafkaConsumerServiceTest {
 
         verify(kafkaTranslatorInterface).translateLetterKafkaMessage(validLetterMessage);
         verify(apiIntegrationInterface).sendLetterMessageToIntegrationApi(mockLetterRequest, acknowledgment);
-        verify(acknowledgment).acknowledge();
     }
 
     @Test
@@ -79,7 +78,7 @@ public class KafkaConsumerServiceTest {
         assertThrows(IllegalArgumentException.class, () -> kafkaConsumerService.consumeEmailMessage(mockRecord, acknowledgment));
 
         verifyNoInteractions(apiIntegrationInterface);
-        verify(acknowledgment, never()).acknowledge(); // Verify acknowledgment is not called
+        verify(acknowledgment, never()).acknowledge();
     }
 
     @Test


### PR DESCRIPTION
This PR addresses a potential oversight/missing implementation detail regarding acknowledgement handling. Since this wasn't part of Jason's original scope in https://github.com/companieshouse/chs-notification-kafka-consumer/pull/10 - I didn't want to block his work with these changes, so made a separate PR.

The PR modifies the service to ensure acknowledgements only happen when requests succeed. If a request fails, we don't acknowledge it, allowing failed messages to be reconsumed by the Kafka topic. 

Key changes include:
- Modified ApiIntegrationInterface to include a Runnable onSuccess callback
- Updated implementation to only execute acknowledgement on successful API calls
- Switched from retrieve() to exchangeToMono() in WebClient implementation
- Added proper error logging for failures
- Updated tests to verify correct callback behavior
- Verified acknowledgement is not called in error scenarios

This improves reliability by preventing premature acknowledgement before confirming successful delivery to downstream systems.  I'm not sure on the nitty gritty details of idempotency and how/if we're handling that, so I may look into that and  see if any changes need made related, but not part of this PR.