### PR TITLE
fix(deep-bau) critical Kafka consumer failure by renaming 'record' variable

### DIFF
--- a/src/main/java/uk/gov/companieshouse/chs/notification/kafka/consumer/kafkaintegration/KafkaConsumerService.java
+++ b/src/main/java/uk/gov/companieshouse/chs/notification/kafka/consumer/kafkaintegration/KafkaConsumerService.java
@@ -45,30 +45,30 @@ class KafkaConsumerService {
     @KafkaListener(topics = "${kafka.topic.email}",
             groupId = "${kafka.group-id.email}",
             containerFactory = "listenerContainerFactoryEmail")
-    public void consumeEmailMessage(ConsumerRecord<String, byte[]> record, Acknowledgment acknowledgment) {
+    public void consumeEmailMessage(ConsumerRecord<String, byte[]> consumerRecord, Acknowledgment acknowledgment) {
         LOG.info("Consuming email message");
 
         // TODO: don't acknowledge null or empty records, figure out WHY they are null, and prevent it from happening
-        if (record == null) {
+        if (consumerRecord == null) {
             LOG.info("Record is null, acknowledging message");
             acknowledgment.acknowledge();
             return;
         }
 
-        if (record.value() == null) {
+        if (consumerRecord.value() == null) {
             LOG.info("Record value is null, acknowledging message");
             acknowledgment.acknowledge();
             return;
         }
 
-        if (record.value().length == 0) {
+        if (consumerRecord.value().length == 0) {
             LOG.info("Record value is empty, acknowledging message");
             acknowledgment.acknowledge();
             return;
         }
 
         LOG.info("Record is valid, and has data");
-        final var emailRequest = kafkaTranslatorInterface.translateEmailKafkaMessage(record.value());
+        final var emailRequest = kafkaTranslatorInterface.translateEmailKafkaMessage(consumerRecord.value());
         LOG.info("Translated letter request");
         apiIntegrationInterface.sendEmailMessageToIntegrationApi(emailRequest, acknowledgment::acknowledge);
         LOG.info("Sent letter message to integration API");
@@ -89,30 +89,30 @@ class KafkaConsumerService {
     @KafkaListener(topics = "${kafka.topic.letter}",
             groupId = "${kafka.group-id.letter}",
             containerFactory = "listenerContainerFactoryLetter")
-    public void consumeLetterMessage(ConsumerRecord<String, byte[]> record, Acknowledgment acknowledgment) {
+    public void consumeLetterMessage(ConsumerRecord<String, byte[]> consumerRecord, Acknowledgment acknowledgment) {
         LOG.info("Consuming letter message");
 
         // TODO: don't acknowledge null or empty records, figure out WHY they are null, and prevent it from happening
-        if (record == null) {
+        if (consumerRecord == null) {
             LOG.info("Record is null, acknowledging message");
             acknowledgment.acknowledge();
             return;
         }
 
-        if (record.value() == null) {
+        if (consumerRecord.value() == null) {
             LOG.info("Record value is null, acknowledging message");
             acknowledgment.acknowledge();
             return;
         }
 
-        if (record.value().length == 0) {
+        if (consumerRecord.value().length == 0) {
             LOG.info("Record value is empty, acknowledging message");
             acknowledgment.acknowledge();
             return;
         }
 
         LOG.info("Record is valid, and has data");
-        final var letterRequest = kafkaTranslatorInterface.translateLetterKafkaMessage(record.value());
+        final var letterRequest = kafkaTranslatorInterface.translateLetterKafkaMessage(consumerRecord.value());
         LOG.info("Translated letter request");
         apiIntegrationInterface.sendLetterMessageToIntegrationApi(letterRequest, acknowledgment::acknowledge);
         LOG.info("Sent letter message to integration API");


### PR DESCRIPTION
- Renamed parameter variable from 'record' to 'consumerRecord' in both consumeEmailMessage and consumeLetterMessage methods
- Updated all references throughout both methods
- Resolves runtime failure where 'record' parameter was conflicting with Java's contextual keyword, causing immediate retry loops
- Prevents service instability and unnecessary message reprocessing
