### PR TITLE
Deep 296 tech debt   refactor application logging to use structured logging chs notification kafka consumer

### DIFF
--- a/src/main/java/uk/gov/companieshouse/chs/notification/kafka/consumer/apiintegration/NotifyIntegrationService.java
+++ b/src/main/java/uk/gov/companieshouse/chs/notification/kafka/consumer/apiintegration/NotifyIntegrationService.java
@@ -39,7 +39,7 @@ public class NotifyIntegrationService {
                 .doOnError(WebClientResponseException.class, err -> {
                     var logMap = new DataMap.Builder()
                             .uri("/email")
-                            .message(err.getMessage())
+                            .errorMessage(err.getMessage())
                             .status(Objects.toString(err.getStatusCode().value()))
                             .build().getLogMap();
                     LOG.error("Email API call failed", new Exception(err), logMap);

--- a/src/main/java/uk/gov/companieshouse/chs/notification/kafka/consumer/apiintegration/NotifyIntegrationService.java
+++ b/src/main/java/uk/gov/companieshouse/chs/notification/kafka/consumer/apiintegration/NotifyIntegrationService.java
@@ -1,41 +1,68 @@
 package uk.gov.companieshouse.chs.notification.kafka.consumer.apiintegration;
 
+import static uk.gov.companieshouse.chs.notification.kafka.consumer.ChsNotificationKafkaConsumerApplication.APPLICATION_NAMESPACE;
+
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
+import java.util.Objects;
 import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
 import uk.gov.companieshouse.api.chs.notification.model.GovUkEmailDetailsRequest;
 import uk.gov.companieshouse.api.chs.notification.model.GovUkLetterDetailsRequest;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+import uk.gov.companieshouse.logging.util.DataMap;
 
 @Validated
 @Service
 public class NotifyIntegrationService {
 
     private final WebClient notifyIntegrationWebClient;
+    private static final Logger LOG = LoggerFactory.getLogger(APPLICATION_NAMESPACE);
 
     public NotifyIntegrationService(final WebClient integrationWebClient) {
         this.notifyIntegrationWebClient = integrationWebClient;
     }
 
-    public Mono<Void> sendEmailMessageToIntegrationApi(@NotNull @Valid final GovUkEmailDetailsRequest govUkEmailDetailsRequest) {
+    public Mono<Void> sendEmailMessageToIntegrationApi(
+            @NotNull @Valid final GovUkEmailDetailsRequest govUkEmailDetailsRequest) {
+
         return notifyIntegrationWebClient.post()
                 .uri("/email")
                 .header("Content-Type", "application/json")
                 .bodyValue(govUkEmailDetailsRequest)
                 .retrieve()
                 .toBodilessEntity()
+                .doOnError(WebClientResponseException.class, err -> {
+                    var logMap = new DataMap.Builder()
+                            .uri("/email")
+                            .message(err.getMessage())
+                            .status(Objects.toString(err.getStatusCode().value()))
+                            .build().getLogMap();
+                    LOG.error("Email API call failed", new Exception(err), logMap);
+                })
                 .then();
     }
 
-    public Mono<Void> sendLetterMessageToIntegrationApi(@NotNull @Valid final GovUkLetterDetailsRequest govUkLetterDetailsRequest) {
+    public Mono<Void> sendLetterMessageToIntegrationApi(
+            @NotNull @Valid final GovUkLetterDetailsRequest govUkLetterDetailsRequest) {
         return notifyIntegrationWebClient.post()
                 .uri("/letter")
                 .header("Content-Type", "application/json")
                 .bodyValue(govUkLetterDetailsRequest)
                 .retrieve()
                 .toBodilessEntity()
+                .doOnError(WebClientResponseException.class, err -> {
+                    var logMap = new DataMap.Builder()
+                            .uri("/letter")
+                            .message(err.getMessage())
+                            .status(Objects.toString(err.getStatusCode().value()))
+                            .build().getLogMap();
+                    LOG.error("Letter API call failed", new Exception(err), logMap);
+                })
                 .then();
     }
 }

--- a/src/test/java/helpers/OutputCapture.java
+++ b/src/test/java/helpers/OutputCapture.java
@@ -1,0 +1,115 @@
+package helpers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import org.apache.commons.io.output.TeeOutputStream;
+
+public class OutputCapture implements AutoCloseable {
+
+    private final PrintStream originalOut;
+    private final ByteArrayOutputStream outBuffer;
+    private final TeeOutputStream teeOut;
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private final PrintStream capturedStream;
+
+    public OutputCapture() {
+        this.originalOut = System.out;
+        this.outBuffer = new ByteArrayOutputStream();
+        this.teeOut = new TeeOutputStream(originalOut, outBuffer);
+        this.capturedStream = new PrintStream(teeOut, true, StandardCharsets.UTF_8);
+        System.setOut(this.capturedStream);
+    }
+
+    /**
+     * This should give a String representation of everything that has been sent to standard out
+     * since this class has been initialised or since reset() was called
+     *
+     * @return A String of everything captured by this class
+     */
+    public synchronized String getOutput() {
+        return outBuffer.toString(StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Return JSON lines in output as a JsonNode. <br>
+     * <b>Note:</b> Most lines in the output will likely not be JSON this will skip over the ones
+     * that are not
+     *
+     * @return List<JsonNode> containing the data within the JSON output lines
+     */
+    public synchronized List<JsonNode> getJsonEntries() {
+        return getOutput().lines()
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .map(s -> {
+                    try {
+                        return MAPPER.readTree(s);
+                    } catch (IOException e) {
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
+    /**
+     * Find the entry where "event" == eventName and return the entire entry at the given index.
+     *
+     * @param eventName The name of the event to search for
+     * @param index     The index of the event to find (0-based)
+     * @return Optional containing the JsonNode if found, otherwise empty
+     */
+    public synchronized Optional<JsonNode> findEntryByEvent(String eventName, int index) {
+        return getJsonEntries().stream()
+                .filter(
+                        node -> node.has("event")
+                                && eventName.equals(node.get("event").asText())
+                )
+                .skip(index)
+                .findFirst();
+    }
+
+    /**
+     * Retrieve the "data" field from the entry where "event" == eventName at the specified index.
+     *
+     * @param eventName The name of the event to search for
+     * @param index     The index of the event to find (0-based)
+     * @return Optional containing the "data" field if found, otherwise empty
+     */
+    public Optional<JsonNode> findDataByEvent(String eventName, int index) {
+        return findEntryByEvent(eventName, index).map(node -> node.get("data"));
+    }
+
+    public long findAmountByEvent(String eventName) {
+        return getJsonEntries().stream()
+                .filter(
+                        node -> node.has("event")
+                                && eventName.equals(node.get("event").asText())
+                )
+                .count();
+    }
+
+    /**
+     * Clears stdout buffer, allowing for fresh captures in subsequent tests.
+     */
+    public synchronized void reset() {
+        outBuffer.reset();
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            teeOut.flush();
+            capturedStream.flush();
+        } finally {
+            System.setOut(originalOut);
+        }
+    }
+}

--- a/src/test/java/helpers/OutputCapture.java
+++ b/src/test/java/helpers/OutputCapture.java
@@ -25,6 +25,7 @@ public class OutputCapture implements AutoCloseable {
         this.teeOut = new TeeOutputStream(originalOut, outBuffer);
         this.capturedStream = new PrintStream(teeOut, true, StandardCharsets.UTF_8);
         System.setOut(this.capturedStream);
+        System.out.flush();
     }
 
     /**

--- a/src/test/java/helpers/utils/OutputAssertions.java
+++ b/src/test/java/helpers/utils/OutputAssertions.java
@@ -1,0 +1,46 @@
+package helpers.utils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import helpers.OutputCapture;
+import org.junit.jupiter.api.Assertions;
+
+public class OutputAssertions {
+
+    /**
+     * Helper to extract the “data” object from a captured log entry.
+     *
+     * @param capture the OutputCapture instance containing the logs
+     * @param event   the log level/event name (“debug”, “info”, “error”, etc.)
+     * @param index   which occurrence of that event to grab (0-based)
+     * @return the “data” JsonNode for that entry
+     * @throws AssertionError if the entry or its “data” field is missing
+     */
+    public static JsonNode getDataFromLog(OutputCapture capture, String event, int index) {
+        JsonNode entry = capture.findEntryByEvent(event, index)
+                .orElseThrow(() -> new AssertionError(
+                        "Missing '" + event + "' log entry at index " + index));
+        JsonNode data = entry.get("data");
+        if (data == null) {
+            throw new AssertionError(
+                    "Missing 'data' field in '" + event + "' entry at index " + index);
+        }
+        return data;
+    }
+
+    /**
+     * Helper to assert that a JSON node has a specific field and that the field's value matches the
+     * expected value.
+     *
+     * @param jsonNode      the JsonNode to check
+     * @param fieldName     the name of the field to check
+     * @param expectedValue the expected value of the field
+     */
+    public static void assertJsonHasAndEquals(JsonNode jsonNode, String fieldName,
+            String expectedValue) {
+        Assertions.assertNotNull(jsonNode,
+                "JSON node for field '" + fieldName + "' should not be null");
+        Assertions.assertTrue(jsonNode.has(fieldName), "JSON should contain field: " + fieldName);
+        Assertions.assertEquals(expectedValue, jsonNode.get(fieldName).asText(),
+                "Field '" + fieldName + "' should match expected");
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/chs/notification/kafka/consumer/apiintegration/ApiIntegrationInterfaceTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/notification/kafka/consumer/apiintegration/ApiIntegrationInterfaceTest.java
@@ -4,7 +4,6 @@ import helpers.OutputCapture;
 import jakarta.validation.ConstraintViolationException;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.Objects;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,7 +16,6 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 import reactor.core.publisher.Mono;
 import uk.gov.companieshouse.api.chs.notification.model.GovUkEmailDetailsRequest;
 import uk.gov.companieshouse.api.chs.notification.model.GovUkLetterDetailsRequest;
-import uk.gov.companieshouse.logging.util.DataMap;
 
 import static helpers.utils.OutputAssertions.assertJsonHasAndEquals;
 import static helpers.utils.OutputAssertions.getDataFromLog;

--- a/src/test/java/uk/gov/companieshouse/chs/notification/kafka/consumer/kafkaintegration/KafkaConsumerServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/notification/kafka/consumer/kafkaintegration/KafkaConsumerServiceTest.java
@@ -1,6 +1,9 @@
 package uk.gov.companieshouse.chs.notification.kafka.consumer.kafkaintegration;
 
+import helpers.OutputCapture;
+import com.fasterxml.jackson.databind.JsonNode;
 import consumer.exception.NonRetryableErrorException;
+import java.io.IOException;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -20,8 +23,11 @@ import uk.gov.companieshouse.notification.ChsEmailNotification;
 import uk.gov.companieshouse.notification.ChsLetterNotification;
 import uk.gov.companieshouse.notification.SenderDetails;
 
+
+import static helpers.utils.OutputAssertions.assertJsonHasAndEquals;
+import static helpers.utils.OutputAssertions.getDataFromLog;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.eq;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -73,13 +79,30 @@ class KafkaConsumerServiceTest {
     }
 
     @Test
-    void When_ConsumingValidEmailMessage_Expect_MessageSentAndAcknowledged() {
+    void When_ConsumingValidEmailMessage_Expect_MessageSentAndAcknowledged() throws IOException {
         // Given
-        when(messageMapper.mapToEmailDetailsRequest(mockEmailNotification)).thenReturn(mockEmailRequest);
-        when(notifyIntegrationService.sendEmailMessageToIntegrationApi(mockEmailRequest)).thenReturn(Mono.empty());
+        when(messageMapper.mapToEmailDetailsRequest(mockEmailNotification)).thenReturn(
+                mockEmailRequest);
+        when(notifyIntegrationService.sendEmailMessageToIntegrationApi(
+                mockEmailRequest)).thenReturn(Mono.empty());
 
-        // When
-        kafkaConsumerService.consumeEmailMessage(emailRecord, acknowledgment);
+        try (var outputCapture = new OutputCapture()) {
+            // When
+            kafkaConsumerService.consumeEmailMessage(emailRecord, acknowledgment);
+
+            // Debug Log Message
+            var debugData = getDataFromLog(outputCapture, "debug", 0);
+            assertJsonHasAndEquals(debugData, "message",
+                    "Consuming email record: " + emailRecord);
+            assertCommonFields(debugData, EMAIL_TOPIC, mockEmailNotification.toString());
+
+            // Info Log Message
+            var infoData = getDataFromLog(outputCapture, "info", 0);
+            assertJsonHasAndEquals(infoData, "message",
+                    "Consuming email record with sender reference: email-ref-123");
+            assertCommonFields(infoData, EMAIL_TOPIC, mockEmailNotification.toString());
+
+        }
 
         // Then
         verify(messageMapper).mapToEmailDetailsRequest(mockEmailNotification);
@@ -88,13 +111,30 @@ class KafkaConsumerServiceTest {
     }
 
     @Test
-    void When_ConsumingValidLetterMessage_Expect_MessageSentAndAcknowledged() {
+    void When_ConsumingValidLetterMessage_Expect_MessageSentAndAcknowledged() throws IOException {
         // Given
-        when(messageMapper.mapToLetterDetailsRequest(mockLetterNotification)).thenReturn(mockLetterRequest);
-        when(notifyIntegrationService.sendLetterMessageToIntegrationApi(mockLetterRequest)).thenReturn(Mono.empty());
+        when(messageMapper.mapToLetterDetailsRequest(mockLetterNotification)).thenReturn(
+                mockLetterRequest);
+        when(notifyIntegrationService.sendLetterMessageToIntegrationApi(
+                mockLetterRequest)).thenReturn(Mono.empty());
 
-        // When
-        kafkaConsumerService.consumeLetterMessage(letterRecord, acknowledgment);
+        try (var outputCapture = new OutputCapture()) {
+            // When
+            kafkaConsumerService.consumeLetterMessage(letterRecord, acknowledgment);
+
+            // Debug Log Message
+            var debugData = getDataFromLog(outputCapture, "debug", 0);
+            assertJsonHasAndEquals(debugData, "message",
+                    "Consuming letter record: " + letterRecord);
+            assertCommonFields(debugData, LETTER_TOPIC, mockLetterNotification.toString());
+
+            // Info Log Message
+            var infoData = getDataFromLog(outputCapture, "info", 0);
+            assertJsonHasAndEquals(infoData, "message",
+                    "Consuming letter record with sender reference: letter-ref-456");
+            assertCommonFields(infoData, LETTER_TOPIC, mockLetterNotification.toString());
+
+        }
 
         // Then
         verify(messageMapper).mapToLetterDetailsRequest(mockLetterNotification);
@@ -103,14 +143,34 @@ class KafkaConsumerServiceTest {
     }
 
     @Test
-    void When_EmailMessageMappingFails_Expect_ExceptionThrownAndNoAcknowledgment() {
+    void When_EmailMessageMappingFails_Expect_ExceptionThrownAndNoAcknowledgment()
+            throws IOException {
         // Given
         RuntimeException mappingException = new RuntimeException("Mapping failed");
-        when(messageMapper.mapToEmailDetailsRequest(mockEmailNotification)).thenThrow(mappingException);
+        when(messageMapper.mapToEmailDetailsRequest(mockEmailNotification)).thenThrow(
+                mappingException);
 
-        // When/Then
-        assertThrows(RuntimeException.class,
-                () -> kafkaConsumerService.consumeEmailMessage(emailRecord, acknowledgment));
+        try (var outputCapture = new OutputCapture()) {
+            // When/Then
+            assertThrows(RuntimeException.class,
+                    () -> kafkaConsumerService.consumeEmailMessage(emailRecord, acknowledgment));
+
+            // Debug Log Message
+            var debugData = getDataFromLog(outputCapture, "debug", 0);
+            assertJsonHasAndEquals(debugData, "message",
+                    "Consuming email record: " + emailRecord);
+            assertCommonFields(debugData, EMAIL_TOPIC, mockEmailNotification.toString());
+
+            // Info Log Message
+            var infoData = getDataFromLog(outputCapture, "info", 0);
+            assertJsonHasAndEquals(infoData, "message",
+                    "Consuming email record with sender reference: email-ref-123");
+            assertCommonFields(infoData, EMAIL_TOPIC, mockEmailNotification.toString());
+
+            assertEquals(0, outputCapture.findAmountByEvent("error"),
+                    "No error logs should be generated for mapping failure");
+
+        }
 
         // Then
         verify(messageMapper).mapToEmailDetailsRequest(mockEmailNotification);
@@ -119,14 +179,30 @@ class KafkaConsumerServiceTest {
     }
 
     @Test
-    void When_LetterMessageMappingFails_Expect_ExceptionThrownAndNoAcknowledgment() {
+    void When_LetterMessageMappingFails_Expect_ExceptionThrownAndNoAcknowledgment()
+            throws IOException {
         // Given
         RuntimeException mappingException = new RuntimeException("Mapping failed");
-        when(messageMapper.mapToLetterDetailsRequest(mockLetterNotification)).thenThrow(mappingException);
+        when(messageMapper.mapToLetterDetailsRequest(mockLetterNotification)).thenThrow(
+                mappingException);
 
-        // When/Then
-        assertThrows(RuntimeException.class,
-                () -> kafkaConsumerService.consumeLetterMessage(letterRecord, acknowledgment));
+        try (var outputCapture = new OutputCapture()) {
+            // When/Then
+            assertThrows(RuntimeException.class,
+                    () -> kafkaConsumerService.consumeLetterMessage(letterRecord, acknowledgment));
+
+            // Debug Log Message
+            var debugData = getDataFromLog(outputCapture, "debug", 0);
+            assertJsonHasAndEquals(debugData, "message",
+                    "Consuming letter record: " + letterRecord);
+            assertCommonFields(debugData, LETTER_TOPIC, mockLetterNotification.toString());
+
+            // Info Log Message
+            var infoData = getDataFromLog(outputCapture, "info", 0);
+            assertJsonHasAndEquals(infoData, "message",
+                    "Consuming letter record with sender reference: letter-ref-456");
+            assertCommonFields(infoData, LETTER_TOPIC, mockLetterNotification.toString());
+        }
 
         // Then
         verify(messageMapper).mapToLetterDetailsRequest(mockLetterNotification);
@@ -135,15 +211,38 @@ class KafkaConsumerServiceTest {
     }
 
     @Test
-    void When_EmailApiIntegrationFails_Expect_ExceptionThrownAndNoAcknowledgment() {
+    void When_EmailApiIntegrationFails_Expect_ExceptionThrownAndNoAcknowledgment()
+            throws IOException {
         // Given
         RuntimeException apiException = new RuntimeException("API failed");
-        when(messageMapper.mapToEmailDetailsRequest(mockEmailNotification)).thenReturn(mockEmailRequest);
-        when(notifyIntegrationService.sendEmailMessageToIntegrationApi(mockEmailRequest)).thenReturn(Mono.error(apiException));
+        when(messageMapper.mapToEmailDetailsRequest(mockEmailNotification)).thenReturn(
+                mockEmailRequest);
+        when(notifyIntegrationService.sendEmailMessageToIntegrationApi(
+                mockEmailRequest)).thenReturn(Mono.error(apiException));
 
-        // When/Then
-        assertThrows(RuntimeException.class,
-                () -> kafkaConsumerService.consumeEmailMessage(emailRecord, acknowledgment));
+        try (var outputCapture = new OutputCapture()) {
+            // When/Then
+            assertThrows(RuntimeException.class,
+                    () -> kafkaConsumerService.consumeEmailMessage(emailRecord, acknowledgment));
+
+            // Debug Log Message
+            var debugData = getDataFromLog(outputCapture, "debug", 0);
+            assertJsonHasAndEquals(debugData, "message",
+                    "Consuming email record: " + emailRecord);
+            assertCommonFields(debugData, EMAIL_TOPIC, mockEmailNotification.toString());
+
+            // Info Log Message
+            var infoData = getDataFromLog(outputCapture, "info", 0);
+            assertJsonHasAndEquals(infoData, "message",
+                    "Consuming email record with sender reference: email-ref-123");
+            assertCommonFields(infoData, EMAIL_TOPIC, mockEmailNotification.toString());
+
+            // Error Log Message
+            var errorData = getDataFromLog(outputCapture, "error", 0);
+            assertJsonHasAndEquals(errorData, "error_message", "API failed");
+            assertCommonFields(errorData, EMAIL_TOPIC, mockEmailNotification.toString());
+
+        }
 
         // Then
         verify(messageMapper).mapToEmailDetailsRequest(mockEmailNotification);
@@ -155,8 +254,10 @@ class KafkaConsumerServiceTest {
     void When_LetterApiIntegrationFails_Expect_ExceptionThrownAndNoAcknowledgment() {
         // Given
         RuntimeException apiException = new RuntimeException("API failed");
-        when(messageMapper.mapToLetterDetailsRequest(mockLetterNotification)).thenReturn(mockLetterRequest);
-        when(notifyIntegrationService.sendLetterMessageToIntegrationApi(mockLetterRequest)).thenReturn(Mono.error(apiException));
+        when(messageMapper.mapToLetterDetailsRequest(mockLetterNotification)).thenReturn(
+                mockLetterRequest);
+        when(notifyIntegrationService.sendLetterMessageToIntegrationApi(
+                mockLetterRequest)).thenReturn(Mono.error(apiException));
 
         // When/Then
         assertThrows(RuntimeException.class,
@@ -169,79 +270,187 @@ class KafkaConsumerServiceTest {
     }
 
     @Test
-    void When_EmailApiIntegrationFailsThenSucceeds_Expect_MessageRetryAndAcknowledgment() {
+    void When_EmailApiIntegrationFailsThenSucceeds_Expect_MessageRetryAndAcknowledgment()
+            throws IOException {
         // Given - Configure the test class so we can verify behavior across multiple method calls
         KafkaConsumerService spyKafkaConsumerService = Mockito.spy(kafkaConsumerService);
 
         // First call fails, second call succeeds
-        when(messageMapper.mapToEmailDetailsRequest(mockEmailNotification)).thenReturn(mockEmailRequest);
-        when(notifyIntegrationService.sendEmailMessageToIntegrationApi(mockEmailRequest))
-                .thenReturn(Mono.error(new RuntimeException("First attempt failed")))
-                .thenReturn(Mono.empty());
+        when(messageMapper.mapToEmailDetailsRequest(mockEmailNotification)).thenReturn(
+                mockEmailRequest);
+        when(notifyIntegrationService.sendEmailMessageToIntegrationApi(
+                mockEmailRequest)).thenReturn(
+                Mono.error(new RuntimeException("First attempt failed"))).thenReturn(Mono.empty());
 
-        // When - First call will throw exception
-        assertThrows(RuntimeException.class,
-                () -> spyKafkaConsumerService.consumeEmailMessage(emailRecord, acknowledgment));
+        try (var outputCapture = new OutputCapture()) {
+            // When - First call will throw exception
+            assertThrows(RuntimeException.class,
+                    () -> spyKafkaConsumerService.consumeEmailMessage(emailRecord, acknowledgment));
+
+            // Debug Log Message
+            var debugData = getDataFromLog(outputCapture, "debug", 0);
+            assertJsonHasAndEquals(debugData, "message",
+                    "Consuming email record: " + emailRecord);
+            assertCommonFields(debugData, EMAIL_TOPIC, mockEmailNotification.toString());
+
+            // Info Log Message
+            var infoData = getDataFromLog(outputCapture, "info", 0);
+            assertJsonHasAndEquals(infoData, "message",
+                    "Consuming email record with sender reference: email-ref-123");
+            assertCommonFields(infoData, EMAIL_TOPIC, mockEmailNotification.toString());
+
+            // Error Log Message
+            var errorData = getDataFromLog(outputCapture, "error", 0);
+            assertJsonHasAndEquals(errorData, "error_message", "First attempt failed");
+            assertCommonFields(errorData, EMAIL_TOPIC, mockEmailNotification.toString());
+
+        }
 
         // Verify first attempt behavior
         verify(messageMapper).mapToEmailDetailsRequest(mockEmailNotification);
         verify(notifyIntegrationService).sendEmailMessageToIntegrationApi(mockEmailRequest);
         verifyNoInteractions(acknowledgment);
 
-        // When - Second call should succeed
-        spyKafkaConsumerService.consumeEmailMessage(emailRecord, acknowledgment);
+        try (var outputCapture = new OutputCapture()) {
+            // When - Second call should succeed
+            spyKafkaConsumerService.consumeEmailMessage(emailRecord, acknowledgment);
 
+            // Debug Log Message
+            var debugData = getDataFromLog(outputCapture, "debug", 0);
+            assertJsonHasAndEquals(debugData, "message",
+                    "Consuming email record: " + emailRecord);
+            assertCommonFields(debugData, EMAIL_TOPIC, mockEmailNotification.toString());
+
+            // Info Log Message
+            var infoData = getDataFromLog(outputCapture, "info", 0);
+            assertJsonHasAndEquals(infoData, "message",
+                    "Consuming email record with sender reference: email-ref-123");
+            assertCommonFields(infoData, EMAIL_TOPIC, mockEmailNotification.toString());
+        }
         // Then - Verify the retry succeeded and was acknowledged
         verify(messageMapper, times(2)).mapToEmailDetailsRequest(mockEmailNotification);
-        verify(notifyIntegrationService, times(2)).sendEmailMessageToIntegrationApi(mockEmailRequest);
+        verify(notifyIntegrationService, times(2)).sendEmailMessageToIntegrationApi(
+                mockEmailRequest);
         verify(acknowledgment).acknowledge();
     }
 
     @Test
-    void When_LetterApiIntegrationFailsThenSucceeds_Expect_MessageRetryAndAcknowledgment() {
+    void When_LetterApiIntegrationFailsThenSucceeds_Expect_MessageRetryAndAcknowledgment()
+            throws IOException {
         // Given - Configure the test class so we can verify behavior across multiple method calls
         KafkaConsumerService spyKafkaConsumerService = Mockito.spy(kafkaConsumerService);
 
         // First call fails, second call succeeds
-        when(messageMapper.mapToLetterDetailsRequest(mockLetterNotification)).thenReturn(mockLetterRequest);
-        when(notifyIntegrationService.sendLetterMessageToIntegrationApi(mockLetterRequest))
-                .thenReturn(Mono.error(new RuntimeException("First attempt failed")))
-                .thenReturn(Mono.empty());
+        when(messageMapper.mapToLetterDetailsRequest(mockLetterNotification)).thenReturn(
+                mockLetterRequest);
+        when(notifyIntegrationService.sendLetterMessageToIntegrationApi(
+                mockLetterRequest)).thenReturn(
+                Mono.error(new RuntimeException("First attempt failed"))).thenReturn(Mono.empty());
 
-        // When - First call will throw exception
-        assertThrows(RuntimeException.class,
-                () -> spyKafkaConsumerService.consumeLetterMessage(letterRecord, acknowledgment));
+        try (var outputCapture = new OutputCapture()) {
+            // When - First call will throw exception
+            assertThrows(RuntimeException.class,
+                    () -> spyKafkaConsumerService.consumeLetterMessage(letterRecord,
+                            acknowledgment));
+
+            // Debug Log Message
+            var debugData = getDataFromLog(outputCapture, "debug", 0);
+            assertJsonHasAndEquals(debugData, "message",
+                    "Consuming letter record: " + letterRecord);
+            assertCommonFields(debugData, LETTER_TOPIC, mockLetterNotification.toString());
+
+            // Info Log Message
+            var infoData = getDataFromLog(outputCapture, "info", 0);
+            assertJsonHasAndEquals(infoData, "message",
+                    "Consuming letter record with sender reference: letter-ref-456");
+            assertCommonFields(infoData, LETTER_TOPIC, mockLetterNotification.toString());
+
+            // Error Log Message
+            var errorData = getDataFromLog(outputCapture, "error", 0);
+            assertJsonHasAndEquals(errorData, "error_message", "First attempt failed");
+            assertCommonFields(errorData, LETTER_TOPIC, mockLetterNotification.toString());
+        }
 
         // Verify first attempt behavior
         verify(messageMapper).mapToLetterDetailsRequest(mockLetterNotification);
         verify(notifyIntegrationService).sendLetterMessageToIntegrationApi(mockLetterRequest);
+        verify(notifyIntegrationService).sendLetterMessageToIntegrationApi(mockLetterRequest);
         verifyNoInteractions(acknowledgment);
 
         // When - Second call should succeed
-        spyKafkaConsumerService.consumeLetterMessage(letterRecord, acknowledgment);
+        try (var outputCapture = new OutputCapture()) {
+            spyKafkaConsumerService.consumeLetterMessage(letterRecord, acknowledgment);
+
+            // Debug Log Message
+            var debugData = getDataFromLog(outputCapture, "debug", 0);
+            assertJsonHasAndEquals(debugData, "message",
+                    "Consuming letter record: " + letterRecord);
+            assertCommonFields(debugData, "chs-notification-letter",
+                    mockLetterNotification.toString());
+
+            // Test Info Log Message
+            var infoEntry = outputCapture.findEntryByEvent("info", 0)
+                    .orElseThrow(() -> new AssertionError("Expected 'info' event not found"));
+            var infoData = infoEntry.get("data");
+            assertJsonHasAndEquals(infoData, "message",
+                    "Consuming letter record with sender reference: letter-ref-456");
+
+        }
 
         // Then - Verify the retry succeeded and was acknowledged
         verify(messageMapper, times(2)).mapToLetterDetailsRequest(mockLetterNotification);
-        verify(notifyIntegrationService, times(2)).sendLetterMessageToIntegrationApi(mockLetterRequest);
+        verify(notifyIntegrationService, times(2)).sendLetterMessageToIntegrationApi(
+                mockLetterRequest);
         verify(acknowledgment).acknowledge();
     }
 
     @Test
-    void When_NonRetryableErrorOccurs_Expect_ExceptionPropagated() {
+    void When_NonRetryableErrorOccurs_Expect_ExceptionPropagated() throws IOException {
         // Given
-        NonRetryableErrorException nonRetryableError = new NonRetryableErrorException("Do not retry this error");
-        when(messageMapper.mapToEmailDetailsRequest(mockEmailNotification)).thenReturn(mockEmailRequest);
-        when(notifyIntegrationService.sendEmailMessageToIntegrationApi(mockEmailRequest))
-                .thenReturn(Mono.error(nonRetryableError));
+        NonRetryableErrorException nonRetryableError = new NonRetryableErrorException(
+                "Do not retry this error");
+        when(messageMapper.mapToEmailDetailsRequest(mockEmailNotification)).thenReturn(
+                mockEmailRequest);
+        when(notifyIntegrationService.sendEmailMessageToIntegrationApi(
+                mockEmailRequest)).thenReturn(Mono.error(nonRetryableError));
 
-        // When/Then - Exception should propagate without retry
-        assertThrows(NonRetryableErrorException.class,
-                () -> kafkaConsumerService.consumeEmailMessage(emailRecord, acknowledgment));
+        try (var outputCapture = new OutputCapture()) {
+            // When/Then - Exception should propagate without retry
+            assertThrows(NonRetryableErrorException.class,
+                    () -> kafkaConsumerService.consumeEmailMessage(emailRecord, acknowledgment));
+
+            // Test Info Log Message
+            var infoData = getDataFromLog(outputCapture, "info", 0);
+            assertJsonHasAndEquals(infoData, "message",
+                    "Consuming email record with sender reference: email-ref-123");
+            assertCommonFields(infoData, EMAIL_TOPIC, mockEmailNotification.toString());
+
+            // Test Error Log Message
+            var errorData = getDataFromLog(outputCapture, "error", 0);
+            assertJsonHasAndEquals(errorData, "message",
+                    "Failed to send email request to integration API");
+            assertCommonFields(errorData, EMAIL_TOPIC, mockEmailNotification.toString());
+
+            // Test Debug Log Message
+            var debugData = getDataFromLog(outputCapture, "debug", 0);
+            assertJsonHasAndEquals(debugData, "message", "Consuming email record: " + emailRecord);
+            assertCommonFields(debugData, EMAIL_TOPIC, mockEmailNotification.toString());
+
+        }
 
         // Then
         verify(messageMapper).mapToEmailDetailsRequest(mockEmailNotification);
         verify(notifyIntegrationService).sendEmailMessageToIntegrationApi(mockEmailRequest);
         verifyNoInteractions(acknowledgment);
     }
-    
+
+
+    private void assertCommonFields(JsonNode data, String topic, String kafkaMessage) {
+        assertJsonHasAndEquals(data, "topic", topic);
+        assertJsonHasAndEquals(data, "partition", "0");
+        assertJsonHasAndEquals(data, "offset", "0");
+        assertJsonHasAndEquals(data, "kafka_message", kafkaMessage);
+    }
+
+
 }


### PR DESCRIPTION
__JIRA Ticket Number__
[DEEP-296](https://companieshouse.atlassian.net/browse/DEEP-296)

__Short description outlining key changes/additions__

I have added a `Map` created by `DataMap` to the logs already present in `KafkaConsumerService`.

I have also added logging in `NotifyIntegrationService` in case of an error though I can also add logging on success and when it is triggered if need be.

I have also added testing into the tests that have already been created. This is done via capturing the standard out similar to what is done to test logging in the overseas-entities-api, however here output will also still be displayed to the user.

### Type of change

* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [x] I have added unit tests for new code that I have added
* [x] I have added/updated functional tests where appropriate
* [x] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__

[DEEP-296]: https://companieshouse.atlassian.net/browse/DEEP-296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ