### PR TITLE
Deep 296 tech debt   refactor application logging to use structured logging chs notification kafka consumer

### DIFF
--- a/src/main/java/uk/gov/companieshouse/chs/notification/kafka/consumer/apiintegration/NotifyIntegrationService.java
+++ b/src/main/java/uk/gov/companieshouse/chs/notification/kafka/consumer/apiintegration/NotifyIntegrationService.java
@@ -1,41 +1,68 @@
 package uk.gov.companieshouse.chs.notification.kafka.consumer.apiintegration;
 
+import static uk.gov.companieshouse.chs.notification.kafka.consumer.ChsNotificationKafkaConsumerApplication.APPLICATION_NAMESPACE;
+
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
+import java.util.Objects;
 import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
 import uk.gov.companieshouse.api.chs.notification.model.GovUkEmailDetailsRequest;
 import uk.gov.companieshouse.api.chs.notification.model.GovUkLetterDetailsRequest;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+import uk.gov.companieshouse.logging.util.DataMap;
 
 @Validated
 @Service
 public class NotifyIntegrationService {
 
     private final WebClient notifyIntegrationWebClient;
+    private static final Logger LOG = LoggerFactory.getLogger(APPLICATION_NAMESPACE);
 
     public NotifyIntegrationService(final WebClient integrationWebClient) {
         this.notifyIntegrationWebClient = integrationWebClient;
     }
 
-    public Mono<Void> sendEmailMessageToIntegrationApi(@NotNull @Valid final GovUkEmailDetailsRequest govUkEmailDetailsRequest) {
+    public Mono<Void> sendEmailMessageToIntegrationApi(
+            @NotNull @Valid final GovUkEmailDetailsRequest govUkEmailDetailsRequest) {
+
         return notifyIntegrationWebClient.post()
                 .uri("/email")
                 .header("Content-Type", "application/json")
                 .bodyValue(govUkEmailDetailsRequest)
                 .retrieve()
                 .toBodilessEntity()
+                .doOnError(WebClientResponseException.class, err -> {
+                    var logMap = new DataMap.Builder()
+                            .uri("/email")
+                            .errorMessage(err.getMessage())
+                            .status(Objects.toString(err.getStatusCode().value()))
+                            .build().getLogMap();
+                    LOG.error("Email API call failed", new Exception(err), logMap);
+                })
                 .then();
     }
 
-    public Mono<Void> sendLetterMessageToIntegrationApi(@NotNull @Valid final GovUkLetterDetailsRequest govUkLetterDetailsRequest) {
+    public Mono<Void> sendLetterMessageToIntegrationApi(
+            @NotNull @Valid final GovUkLetterDetailsRequest govUkLetterDetailsRequest) {
         return notifyIntegrationWebClient.post()
                 .uri("/letter")
                 .header("Content-Type", "application/json")
                 .bodyValue(govUkLetterDetailsRequest)
                 .retrieve()
                 .toBodilessEntity()
+                .doOnError(WebClientResponseException.class, err -> {
+                    var logMap = new DataMap.Builder()
+                            .uri("/letter")
+                            .message(err.getMessage())
+                            .status(Objects.toString(err.getStatusCode().value()))
+                            .build().getLogMap();
+                    LOG.error("Letter API call failed", new Exception(err), logMap);
+                })
                 .then();
     }
 }

--- a/src/main/java/uk/gov/companieshouse/chs/notification/kafka/consumer/kafkaintegration/KafkaConsumerService.java
+++ b/src/main/java/uk/gov/companieshouse/chs/notification/kafka/consumer/kafkaintegration/KafkaConsumerService.java
@@ -25,7 +25,7 @@ import static uk.gov.companieshouse.chs.notification.kafka.consumer.ChsNotificat
 @Service
 class KafkaConsumerService {
 
-    static final Logger LOG = LoggerFactory.getLogger(APPLICATION_NAMESPACE);
+    private static final Logger LOG = LoggerFactory.getLogger(APPLICATION_NAMESPACE);
 
     private final NotifyIntegrationService notifyIntegrationService;
     private final MessageMapper messageMapper;

--- a/src/test/java/helpers/OutputCapture.java
+++ b/src/test/java/helpers/OutputCapture.java
@@ -1,0 +1,116 @@
+package helpers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import org.apache.commons.io.output.TeeOutputStream;
+
+public class OutputCapture implements AutoCloseable {
+
+    private final PrintStream originalOut;
+    private final ByteArrayOutputStream outBuffer;
+    private final TeeOutputStream teeOut;
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private final PrintStream capturedStream;
+
+    public OutputCapture() {
+        this.originalOut = System.out;
+        this.outBuffer = new ByteArrayOutputStream();
+        this.teeOut = new TeeOutputStream(originalOut, outBuffer);
+        this.capturedStream = new PrintStream(teeOut, true, StandardCharsets.UTF_8);
+        System.setOut(this.capturedStream);
+        System.out.flush();
+    }
+
+    /**
+     * This should give a String representation of everything that has been sent to standard out
+     * since this class has been initialised or since reset() was called
+     *
+     * @return A String of everything captured by this class
+     */
+    public synchronized String getOutput() {
+        return outBuffer.toString(StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Return JSON lines in output as a JsonNode. <br>
+     * <b>Note:</b> Most lines in the output will likely not be JSON this will skip over the ones
+     * that are not
+     *
+     * @return List<JsonNode> containing the data within the JSON output lines
+     */
+    public synchronized List<JsonNode> getJsonEntries() {
+        return getOutput().lines()
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .map(s -> {
+                    try {
+                        return MAPPER.readTree(s);
+                    } catch (IOException e) {
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
+    /**
+     * Find the entry where "event" == eventName and return the entire entry at the given index.
+     *
+     * @param eventName The name of the event to search for
+     * @param index     The index of the event to find (0-based)
+     * @return Optional containing the JsonNode if found, otherwise empty
+     */
+    public synchronized Optional<JsonNode> findEntryByEvent(String eventName, int index) {
+        return getJsonEntries().stream()
+                .filter(
+                        node -> node.has("event")
+                                && eventName.equals(node.get("event").asText())
+                )
+                .skip(index)
+                .findFirst();
+    }
+
+    /**
+     * Retrieve the "data" field from the entry where "event" == eventName at the specified index.
+     *
+     * @param eventName The name of the event to search for
+     * @param index     The index of the event to find (0-based)
+     * @return Optional containing the "data" field if found, otherwise empty
+     */
+    public Optional<JsonNode> findDataByEvent(String eventName, int index) {
+        return findEntryByEvent(eventName, index).map(node -> node.get("data"));
+    }
+
+    public long findAmountByEvent(String eventName) {
+        return getJsonEntries().stream()
+                .filter(
+                        node -> node.has("event")
+                                && eventName.equals(node.get("event").asText())
+                )
+                .count();
+    }
+
+    /**
+     * Clears stdout buffer, allowing for fresh captures in subsequent tests.
+     */
+    public synchronized void reset() {
+        outBuffer.reset();
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            teeOut.flush();
+            capturedStream.flush();
+        } finally {
+            System.setOut(originalOut);
+        }
+    }
+}

--- a/src/test/java/helpers/OutputCapture.java
+++ b/src/test/java/helpers/OutputCapture.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import org.apache.commons.io.output.TeeOutputStream;
+import uk.gov.companieshouse.logging.EventType;
 
 public class OutputCapture implements AutoCloseable {
 
@@ -67,11 +68,11 @@ public class OutputCapture implements AutoCloseable {
      * @param index     The index of the event to find (0-based)
      * @return Optional containing the JsonNode if found, otherwise empty
      */
-    public synchronized Optional<JsonNode> findEntryByEvent(String eventName, int index) {
+    public synchronized Optional<JsonNode> findEntryByEvent(EventType eventName, int index) {
         return getJsonEntries().stream()
                 .filter(
                         node -> node.has("event")
-                                && eventName.equals(node.get("event").asText())
+                                && eventName.getName().equals(node.get("event").asText())
                 )
                 .skip(index)
                 .findFirst();
@@ -84,15 +85,15 @@ public class OutputCapture implements AutoCloseable {
      * @param index     The index of the event to find (0-based)
      * @return Optional containing the "data" field if found, otherwise empty
      */
-    public Optional<JsonNode> findDataByEvent(String eventName, int index) {
+    public Optional<JsonNode> findDataByEvent(EventType eventName, int index) {
         return findEntryByEvent(eventName, index).map(node -> node.get("data"));
     }
 
-    public long findAmountByEvent(String eventName) {
+    public long findAmountByEvent(EventType eventName) {
         return getJsonEntries().stream()
                 .filter(
                         node -> node.has("event")
-                                && eventName.equals(node.get("event").asText())
+                                && eventName.getName().equals(node.get("event").asText())
                 )
                 .count();
     }

--- a/src/test/java/helpers/utils/OutputAssertions.java
+++ b/src/test/java/helpers/utils/OutputAssertions.java
@@ -32,10 +32,6 @@ public class OutputAssertions {
                     "No log entries found for event: '" + event + "' with a 'data.message' field.");
         }
 
-        System.out.println();
-        System.out.println("--------------------------");
-        System.out.println(matchingEventEntries);
-
         return matchingEventEntries.stream()
                 .filter(e -> message.equals(e.get("message").asText()))
                 .findFirst()

--- a/src/test/java/helpers/utils/OutputAssertions.java
+++ b/src/test/java/helpers/utils/OutputAssertions.java
@@ -4,6 +4,7 @@ package helpers.utils;
 import com.fasterxml.jackson.databind.JsonNode;
 import helpers.OutputCapture;
 import org.junit.jupiter.api.Assertions;
+import uk.gov.companieshouse.logging.EventType;
 
 public class OutputAssertions {
 
@@ -15,21 +16,22 @@ public class OutputAssertions {
      * @return the “data” JsonNode for that entry
      * @throws AssertionError if the entry or its “data” field is missing
      */
-    public static JsonNode getDataFromLogMessage(OutputCapture capture, String event,
+    public static JsonNode getDataFromLogMessage(OutputCapture capture, EventType event,
             String message) {
+        var eventName = event.getName();
         var entries = capture.getJsonEntries();
         if (entries.isEmpty()) {
-            throw new AssertionError("No log entries found for event: " + event);
+            throw new AssertionError("No log entries found for event: " + eventName);
         }
         var matchingEventEntries = entries.stream()
-                .filter(e -> e.has("event") && event.equals(e.get("event").asText()))
+                .filter(e -> e.has("event") && eventName.equals(e.get("event").asText()))
                 .filter(e -> e.has("data") && e.get("data").has("message"))
                 .map(e -> e.get("data"))
                 .toList();
 
         if (matchingEventEntries.isEmpty()) {
             throw new AssertionError(
-                    "No log entries found for event: '" + event + "' with a 'data.message' field.");
+                    "No log entries found for event: '" + eventName + "' with a 'data.message' field.");
         }
 
         return matchingEventEntries.stream()

--- a/src/test/java/helpers/utils/OutputAssertions.java
+++ b/src/test/java/helpers/utils/OutputAssertions.java
@@ -1,0 +1,70 @@
+package helpers.utils;
+
+
+import com.fasterxml.jackson.databind.JsonNode;
+import helpers.OutputCapture;
+import org.junit.jupiter.api.Assertions;
+
+public class OutputAssertions {
+
+    /**
+     * Helper to extract the “data” object from a captured log entry.
+     *
+     * @param capture the OutputCapture instance containing the logs
+     * @param event   the log level/event name (“debug”, “info”, “error”, etc.)
+     * @return the “data” JsonNode for that entry
+     * @throws AssertionError if the entry or its “data” field is missing
+     */
+    public static JsonNode getDataFromLogMessage(OutputCapture capture, String event,
+            String message) {
+        var entries = capture.getJsonEntries();
+        if (entries.isEmpty()) {
+            throw new AssertionError("No log entries found for event: " + event);
+        }
+        var matchingEventEntries = entries.stream()
+                .filter(e -> e.has("event") && event.equals(e.get("event").asText()))
+                .filter(e -> e.has("data") && e.get("data").has("message"))
+                .map(e -> e.get("data"))
+                .toList();
+
+        if (matchingEventEntries.isEmpty()) {
+            throw new AssertionError(
+                    "No log entries found for event: '" + event + "' with a 'data.message' field.");
+        }
+
+        System.out.println();
+        System.out.println("--------------------------");
+        System.out.println(matchingEventEntries);
+
+        return matchingEventEntries.stream()
+                .filter(e -> message.equals(e.get("message").asText()))
+                .findFirst()
+                .orElseThrow(() -> {
+                    String actualMessages = matchingEventEntries.stream()
+                            .map(e -> e.get("message").asText())
+                            .distinct()
+                            .reduce((a, b) -> a + "\n" + b)
+                            .orElse("[no messages found]");
+                    return new AssertionError(
+                            "No log entry found with message:\n  Expected: " + message
+                                    + "\n  Found:    " + actualMessages);
+                });
+    }
+
+    /**
+     * Helper to assert that a JSON node has a specific field and that the field's value matches the
+     * expected value.
+     *
+     * @param jsonNode      the JsonNode to check
+     * @param fieldName     the name of the field to check
+     * @param expectedValue the expected value of the field
+     */
+    public static void assertJsonHasAndEquals(JsonNode jsonNode, String fieldName,
+            String expectedValue) {
+        Assertions.assertNotNull(jsonNode,
+                "JSON node for field '" + fieldName + "' should not be null");
+        Assertions.assertTrue(jsonNode.has(fieldName), "JSON should contain field: " + fieldName);
+        Assertions.assertEquals(expectedValue, jsonNode.get(fieldName).asText(),
+                "Field '" + fieldName + "' should match expected");
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/chs/notification/kafka/consumer/apiintegration/ApiIntegrationInterfaceTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/notification/kafka/consumer/apiintegration/ApiIntegrationInterfaceTest.java
@@ -75,8 +75,8 @@ class ApiIntegrationInterfaceTest {
 
         try (var outputCapture = new OutputCapture()) {
             service.sendEmailMessageToIntegrationApi(new GovUkEmailDetailsRequest())
-                    .onErrorResume(e -> Mono.empty()) // absorb error for test
-                    .block(); // trigger the call
+                    .onErrorResume(e -> Mono.empty())
+                    .block();
 
             var amountOfErrorLogs = outputCapture.findAmountByEvent("error");
             assertEquals(1, amountOfErrorLogs,
@@ -102,8 +102,8 @@ class ApiIntegrationInterfaceTest {
 
         try (var outputCapture = new OutputCapture()) {
             service.sendLetterMessageToIntegrationApi(new GovUkLetterDetailsRequest())
-                    .onErrorResume(e -> Mono.empty()) // absorb error for test
-                    .block(); // trigger the call
+                    .onErrorResume(e -> Mono.empty())
+                    .block();
 
             var amountOfErrorLogs = outputCapture.findAmountByEvent("error");
             assertEquals(1, amountOfErrorLogs,

--- a/src/test/java/uk/gov/companieshouse/chs/notification/kafka/consumer/apiintegration/ApiIntegrationInterfaceTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/notification/kafka/consumer/apiintegration/ApiIntegrationInterfaceTest.java
@@ -16,6 +16,7 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 import reactor.core.publisher.Mono;
 import uk.gov.companieshouse.api.chs.notification.model.GovUkEmailDetailsRequest;
 import uk.gov.companieshouse.api.chs.notification.model.GovUkLetterDetailsRequest;
+import uk.gov.companieshouse.logging.EventType;
 
 import static helpers.utils.OutputAssertions.assertJsonHasAndEquals;
 import static helpers.utils.OutputAssertions.getDataFromLogMessage;
@@ -78,11 +79,12 @@ class ApiIntegrationInterfaceTest {
                     .onErrorResume(e -> Mono.empty())
                     .block();
 
-            var amountOfErrorLogs = outputCapture.findAmountByEvent("error");
+            var amountOfErrorLogs = outputCapture.findAmountByEvent(EventType.ERROR);
             assertEquals(1, amountOfErrorLogs,
                     "Should show an error log for the failed API call");
 
-            var errorLog = getDataFromLogMessage(outputCapture, "error", "Email API call failed");
+            var errorLog = getDataFromLogMessage(outputCapture, EventType.ERROR,
+                    "Email API call failed");
             assertJsonHasAndEquals(errorLog, "uri", "/email");
             assertJsonHasAndEquals(errorLog, "status", "500");
         }
@@ -105,11 +107,12 @@ class ApiIntegrationInterfaceTest {
                     .onErrorResume(e -> Mono.empty())
                     .block();
 
-            var amountOfErrorLogs = outputCapture.findAmountByEvent("error");
+            var amountOfErrorLogs = outputCapture.findAmountByEvent(EventType.ERROR);
             assertEquals(1, amountOfErrorLogs,
                     "Should show an error log for the failed API call");
 
-            var errorLog = getDataFromLogMessage(outputCapture, "error", "Letter API call failed");
+            var errorLog = getDataFromLogMessage(outputCapture, EventType.ERROR,
+                    "Letter API call failed");
             assertJsonHasAndEquals(errorLog, "uri", "/letter");
             assertJsonHasAndEquals(errorLog, "status", "500");
         }
@@ -133,7 +136,7 @@ class ApiIntegrationInterfaceTest {
                     service.sendEmailMessageToIntegrationApi(new GovUkEmailDetailsRequest())
                             .block());
 
-            var amountOfErrorLogs = outputCapture.findAmountByEvent("error");
+            var amountOfErrorLogs = outputCapture.findAmountByEvent(EventType.ERROR);
             assertEquals(0, amountOfErrorLogs,
                     "Should not log an error for a successful response");
         }
@@ -158,7 +161,7 @@ class ApiIntegrationInterfaceTest {
                     service.sendLetterMessageToIntegrationApi(new GovUkLetterDetailsRequest())
                             .block());
 
-            var amountOfErrorLogs = outputCapture.findAmountByEvent("error");
+            var amountOfErrorLogs = outputCapture.findAmountByEvent(EventType.ERROR);
             assertEquals(0, amountOfErrorLogs,
                     "Should not log an error for a successful response");
         }

--- a/src/test/java/uk/gov/companieshouse/chs/notification/kafka/consumer/apiintegration/ApiIntegrationInterfaceTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/notification/kafka/consumer/apiintegration/ApiIntegrationInterfaceTest.java
@@ -1,18 +1,32 @@
 package uk.gov.companieshouse.chs.notification.kafka.consumer.apiintegration;
 
+import helpers.OutputCapture;
 import jakarta.validation.ConstraintViolationException;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
 import uk.gov.companieshouse.api.chs.notification.model.GovUkEmailDetailsRequest;
 import uk.gov.companieshouse.api.chs.notification.model.GovUkLetterDetailsRequest;
 
+import static helpers.utils.OutputAssertions.assertJsonHasAndEquals;
+import static helpers.utils.OutputAssertions.getDataFromLogMessage;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
 @SpringBootTest
 @Tag("unit-test")
 class ApiIntegrationInterfaceTest {
+
 
     @Autowired
     private NotifyIntegrationService notifyIntegrationService;
@@ -27,7 +41,8 @@ class ApiIntegrationInterfaceTest {
     @Test
     void When_EmptyEmailRequest_Expect_ConstraintViolationException() {
         assertThrowsExactly(ConstraintViolationException.class,
-                () -> notifyIntegrationService.sendEmailMessageToIntegrationApi(new GovUkEmailDetailsRequest()),
+                () -> notifyIntegrationService.sendEmailMessageToIntegrationApi(
+                        new GovUkEmailDetailsRequest()),
                 "Should throw ConstraintViolationException for empty email request");
     }
 
@@ -41,7 +56,61 @@ class ApiIntegrationInterfaceTest {
     @Test
     void When_EmptyLetterRequest_Expect_ConstraintViolationException() {
         assertThrowsExactly(ConstraintViolationException.class,
-                () -> notifyIntegrationService.sendLetterMessageToIntegrationApi(new GovUkLetterDetailsRequest()),
+                () -> notifyIntegrationService.sendLetterMessageToIntegrationApi(
+                        new GovUkLetterDetailsRequest()),
                 "Should throw ConstraintViolationException for empty letter request");
     }
+
+    @Test
+    void When_ErrorIsThrown_Expect_ErrorLogMessage() throws IOException {
+        WebClient client = WebClient.builder()
+                .exchangeFunction(request -> Mono.error(
+                        WebClientResponseException.create(
+                                500, "Internal Service Error", null,
+                                "Body Text".getBytes(StandardCharsets.UTF_8), null
+                        )))
+                .build();
+
+        NotifyIntegrationService service = new NotifyIntegrationService(client);
+
+        try (var outputCapture = new OutputCapture()) {
+            service.sendEmailMessageToIntegrationApi(new GovUkEmailDetailsRequest())
+                    .onErrorResume(e -> Mono.empty()) // absorb error for test
+                    .block(); // trigger the call
+
+            var amountOfErrorLogs = outputCapture.findAmountByEvent("error");
+            assertEquals(1, amountOfErrorLogs,
+                    "Should show an error log for the failed API call");
+
+            var errorLog = getDataFromLogMessage(outputCapture, "error", "Email API call failed");
+            assertJsonHasAndEquals(errorLog, "uri", "/email");
+            assertJsonHasAndEquals(errorLog, "status", "500");
+        }
+    }
+
+    @Test
+    void When_ValidEmailRequest_Expect_SuccessfulCall() throws IOException {
+        ExchangeFunction exchangeFunction = clientRequest -> Mono.just(
+                ClientResponse.create(HttpStatus.NO_CONTENT)
+                        .body("")
+                        .build());
+
+        WebClient client = WebClient.builder()
+                .exchangeFunction(exchangeFunction)
+                .build();
+
+        try (var outputCapture = new OutputCapture()) {
+            NotifyIntegrationService service = new NotifyIntegrationService(client);
+
+            var amountOfErrorLogs = outputCapture.findAmountByEvent("error");
+            assertEquals(0, amountOfErrorLogs,
+                    "Should not log an error for a successful response");
+
+            assertDoesNotThrow(() ->
+                    service.sendEmailMessageToIntegrationApi(new GovUkEmailDetailsRequest())
+                            .block());
+        }
+
+    }
+
 }

--- a/src/test/java/uk/gov/companieshouse/chs/notification/kafka/consumer/kafkaintegration/KafkaConsumerServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/notification/kafka/consumer/kafkaintegration/KafkaConsumerServiceTest.java
@@ -59,6 +59,10 @@ class KafkaConsumerServiceTest {
     private ConsumerRecord<String, ChsEmailNotification> emailRecord;
     private ConsumerRecord<String, ChsLetterNotification> letterRecord;
 
+    private static final String ERROR = org.slf4j.event.Level.ERROR.toString().toLowerCase();
+    private static final String DEBUG = org.slf4j.event.Level.DEBUG.toString().toLowerCase();
+    private static final String INFO = org.slf4j.event.Level.INFO.toString().toLowerCase();
+
     @BeforeEach
     void setUp() {
         mockEmailNotification = new ChsEmailNotification();
@@ -90,15 +94,13 @@ class KafkaConsumerServiceTest {
             // When
             kafkaConsumerService.consumeEmailMessage(emailRecord, acknowledgment);
 
-            // Debug Log Message
-            var debugData = getDataFromLogMessage(outputCapture, "debug",
+            var debugData = getDataFromLogMessage(outputCapture, DEBUG,
                     "Consuming email record: " + emailRecord);
-            assertCommonFields(debugData, EMAIL_TOPIC, mockEmailNotification.toString());
+            assertEmailCommonFields(debugData);
 
-            // Info Log Message
-            var infoData = getDataFromLogMessage(outputCapture, "info",
+            var infoData = getDataFromLogMessage(outputCapture, INFO,
                     "Consuming email record with sender reference: email-ref-123");
-            assertCommonFields(infoData, EMAIL_TOPIC, mockEmailNotification.toString());
+            assertEmailCommonFields(infoData);
 
         }
 
@@ -120,15 +122,13 @@ class KafkaConsumerServiceTest {
             // When
             kafkaConsumerService.consumeLetterMessage(letterRecord, acknowledgment);
 
-            // Debug Log Message
-            var debugData = getDataFromLogMessage(outputCapture, "debug",
+            var debugData = getDataFromLogMessage(outputCapture, DEBUG,
                     "Consuming letter record: " + letterRecord);
-            assertCommonFields(debugData, LETTER_TOPIC, mockLetterNotification.toString());
+            assertLetterCommonFields(debugData);
 
-            // Info Log Message
-            var infoData = getDataFromLogMessage(outputCapture, "info",
+            var infoData = getDataFromLogMessage(outputCapture, INFO,
                     "Consuming letter record with sender reference: letter-ref-456");
-            assertCommonFields(infoData, LETTER_TOPIC, mockLetterNotification.toString());
+            assertLetterCommonFields(infoData);
 
         }
 
@@ -151,15 +151,15 @@ class KafkaConsumerServiceTest {
             assertThrows(RuntimeException.class,
                     () -> kafkaConsumerService.consumeEmailMessage(emailRecord, acknowledgment));
 
-            // Debug Log Message
-            var debugData = getDataFromLogMessage(outputCapture, "debug", "Consuming email record: " + emailRecord);
-            assertCommonFields(debugData, EMAIL_TOPIC, mockEmailNotification.toString());
+            var debugData = getDataFromLogMessage(outputCapture, DEBUG,
+                    "Consuming email record: " + emailRecord);
+            assertEmailCommonFields(debugData);
 
-            // Info Log Message
-            var infoData = getDataFromLogMessage(outputCapture, "info", "Consuming email record with sender reference: email-ref-123");
-            assertCommonFields(infoData, EMAIL_TOPIC, mockEmailNotification.toString());
+            var infoData = getDataFromLogMessage(outputCapture, INFO,
+                    "Consuming email record with sender reference: email-ref-123");
+            assertEmailCommonFields(infoData);
 
-            assertEquals(0, outputCapture.findAmountByEvent("error"),
+            assertEquals(0, outputCapture.findAmountByEvent(ERROR),
                     "No error logs should be generated for mapping failure");
 
         }
@@ -183,13 +183,13 @@ class KafkaConsumerServiceTest {
             assertThrows(RuntimeException.class,
                     () -> kafkaConsumerService.consumeLetterMessage(letterRecord, acknowledgment));
 
-            // Debug Log Message
-            var debugData = getDataFromLogMessage(outputCapture, "debug", "Consuming letter record: " + letterRecord);
-            assertCommonFields(debugData, LETTER_TOPIC, mockLetterNotification.toString());
+            var debugData = getDataFromLogMessage(outputCapture, DEBUG,
+                    "Consuming letter record: " + letterRecord);
+            assertLetterCommonFields(debugData);
 
-            // Info Log Message
-            var infoData = getDataFromLogMessage(outputCapture, "info", "Consuming letter record with sender reference: letter-ref-456");
-            assertCommonFields(infoData, LETTER_TOPIC, mockLetterNotification.toString());
+            var infoData = getDataFromLogMessage(outputCapture, INFO,
+                    "Consuming letter record with sender reference: letter-ref-456");
+            assertLetterCommonFields(infoData);
         }
 
         // Then
@@ -213,19 +213,18 @@ class KafkaConsumerServiceTest {
             assertThrows(RuntimeException.class,
                     () -> kafkaConsumerService.consumeEmailMessage(emailRecord, acknowledgment));
 
-            // Debug Log Message
-            var debugData = getDataFromLogMessage(outputCapture, "debug", "Consuming email record: " + emailRecord);
-            assertCommonFields(debugData, EMAIL_TOPIC, mockEmailNotification.toString());
+            var debugData = getDataFromLogMessage(outputCapture, DEBUG,
+                    "Consuming email record: " + emailRecord);
+            assertEmailCommonFields(debugData);
 
-            // Info Log Message
-            var infoData = getDataFromLogMessage(outputCapture, "info", "Consuming email record with sender reference: email-ref-123");
-            assertCommonFields(infoData, EMAIL_TOPIC, mockEmailNotification.toString());
+            var infoData = getDataFromLogMessage(outputCapture, INFO,
+                    "Consuming email record with sender reference: email-ref-123");
+            assertEmailCommonFields(infoData);
 
-            // Error Log Message
-            var errorData = getDataFromLogMessage(outputCapture, "error",
+            var errorData = getDataFromLogMessage(outputCapture, ERROR,
                     "Failed to send email request to integration API");
             assertJsonHasAndEquals(errorData, "error_message", "API failed");
-            assertCommonFields(errorData, EMAIL_TOPIC, mockEmailNotification.toString());
+            assertEmailCommonFields(errorData);
 
         }
 
@@ -272,21 +271,18 @@ class KafkaConsumerServiceTest {
             assertThrows(RuntimeException.class,
                     () -> spyKafkaConsumerService.consumeEmailMessage(emailRecord, acknowledgment));
 
-            // Debug Log Message
-            var debugData = getDataFromLogMessage(outputCapture, "debug",
+            var debugData = getDataFromLogMessage(outputCapture, DEBUG,
                     "Consuming email record: " + emailRecord);
-            assertCommonFields(debugData, EMAIL_TOPIC, mockEmailNotification.toString());
+            assertEmailCommonFields(debugData);
 
-            // Info Log Message
-            var infoData = getDataFromLogMessage(outputCapture, "info",
+            var infoData = getDataFromLogMessage(outputCapture, INFO,
                     "Consuming email record with sender reference: email-ref-123");
-            assertCommonFields(infoData, EMAIL_TOPIC, mockEmailNotification.toString());
+            assertEmailCommonFields(infoData);
 
-            // Error Log Message
-            var errorData = getDataFromLogMessage(outputCapture, "error",
+            var errorData = getDataFromLogMessage(outputCapture, ERROR,
                     "Failed to send email request to integration API");
             assertJsonHasAndEquals(errorData, "error_message", "First attempt failed");
-            assertCommonFields(errorData, EMAIL_TOPIC, mockEmailNotification.toString());
+            assertEmailCommonFields(errorData);
 
         }
 
@@ -299,15 +295,13 @@ class KafkaConsumerServiceTest {
             // When - Second call should succeed
             spyKafkaConsumerService.consumeEmailMessage(emailRecord, acknowledgment);
 
-            // Debug Log Message
-            var debugData = getDataFromLogMessage(outputCapture, "debug",
+            var debugData = getDataFromLogMessage(outputCapture, DEBUG,
                     "Consuming email record: " + emailRecord);
-            assertCommonFields(debugData, EMAIL_TOPIC, mockEmailNotification.toString());
+            assertEmailCommonFields(debugData);
 
-            // Info Log Message
-            var infoData = getDataFromLogMessage(outputCapture, "info",
+            var infoData = getDataFromLogMessage(outputCapture, INFO,
                     "Consuming email record with sender reference: email-ref-123");
-            assertCommonFields(infoData, EMAIL_TOPIC, mockEmailNotification.toString());
+            assertEmailCommonFields(infoData);
         }
         // Then - Verify the retry succeeded and was acknowledged
         verify(messageMapper, times(2)).mapToEmailDetailsRequest(mockEmailNotification);
@@ -335,21 +329,18 @@ class KafkaConsumerServiceTest {
                     () -> spyKafkaConsumerService.consumeLetterMessage(letterRecord,
                             acknowledgment));
 
-            // Debug Log Message
-            var debugData = getDataFromLogMessage(outputCapture, "debug",
+            var debugData = getDataFromLogMessage(outputCapture, DEBUG,
                     "Consuming letter record: " + letterRecord);
-            assertCommonFields(debugData, LETTER_TOPIC, mockLetterNotification.toString());
+            assertLetterCommonFields(debugData);
 
-            // Info Log Message
-            var infoData = getDataFromLogMessage(outputCapture, "info",
+            var infoData = getDataFromLogMessage(outputCapture, INFO,
                     "Consuming letter record with sender reference: letter-ref-456");
-            assertCommonFields(infoData, LETTER_TOPIC, mockLetterNotification.toString());
+            assertLetterCommonFields(infoData);
 
-            // Error Log Message
-            var errorData = getDataFromLogMessage(outputCapture, "error",
+            var errorData = getDataFromLogMessage(outputCapture, ERROR,
                     "Failed to send letter request to integration API");
             assertJsonHasAndEquals(errorData, "error_message", "First attempt failed");
-            assertCommonFields(errorData, LETTER_TOPIC, mockLetterNotification.toString());
+            assertLetterCommonFields(errorData);
         }
 
         // Verify first attempt behavior
@@ -362,14 +353,12 @@ class KafkaConsumerServiceTest {
         try (var outputCapture = new OutputCapture()) {
             spyKafkaConsumerService.consumeLetterMessage(letterRecord, acknowledgment);
 
-            // Debug Log Message
-            var debugData = getDataFromLogMessage(outputCapture, "debug",
+            var debugData = getDataFromLogMessage(outputCapture, DEBUG,
                     "Consuming letter record: " + letterRecord);
-            assertCommonFields(debugData, "chs-notification-letter",
-                    mockLetterNotification.toString());
+            assertLetterCommonFields(debugData);
 
             // Test Info Log Message
-            getDataFromLogMessage(outputCapture, "info",
+            getDataFromLogMessage(outputCapture, INFO,
                     "Consuming letter record with sender reference: letter-ref-456");
 
         }
@@ -397,19 +386,19 @@ class KafkaConsumerServiceTest {
                     () -> kafkaConsumerService.consumeEmailMessage(emailRecord, acknowledgment));
 
             // Test Info Log Message
-            var infoData = getDataFromLogMessage(outputCapture, "info",
+            var infoData = getDataFromLogMessage(outputCapture, INFO,
                     "Consuming email record with sender reference: email-ref-123");
-            assertCommonFields(infoData, EMAIL_TOPIC, mockEmailNotification.toString());
+            assertEmailCommonFields(infoData);
 
             // Test Error Log Message
-            var errorData = getDataFromLogMessage(outputCapture, "error",
+            var errorData = getDataFromLogMessage(outputCapture, ERROR,
                     "Failed to send email request to integration API");
-            assertCommonFields(errorData, EMAIL_TOPIC, mockEmailNotification.toString());
+            assertEmailCommonFields(errorData);
 
             // Test Debug Log Message
-            var debugData = getDataFromLogMessage(outputCapture, "debug",
-                    "Consuming email record: " + emailRecord);
-            assertCommonFields(debugData, EMAIL_TOPIC, mockEmailNotification.toString());
+            var debugData = getDataFromLogMessage(outputCapture, DEBUG,
+"Consuming email record: " + emailRecord);
+            assertEmailCommonFields(debugData);
 
         }
 
@@ -419,6 +408,13 @@ class KafkaConsumerServiceTest {
         verifyNoInteractions(acknowledgment);
     }
 
+    private void assertEmailCommonFields(JsonNode data) {
+        assertCommonFields(data, EMAIL_TOPIC, mockEmailNotification.toString());
+    }
+
+    private void assertLetterCommonFields(JsonNode data) {
+        assertCommonFields(data, LETTER_TOPIC, mockLetterNotification.toString());
+    }
 
     private void assertCommonFields(JsonNode data, String topic, String kafkaMessage) {
         assertJsonHasAndEquals(data, "topic", topic);

--- a/src/test/java/uk/gov/companieshouse/chs/notification/kafka/consumer/kafkaintegration/KafkaConsumerServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/notification/kafka/consumer/kafkaintegration/KafkaConsumerServiceTest.java
@@ -63,6 +63,15 @@ class KafkaConsumerServiceTest {
     private static final String DEBUG = org.slf4j.event.Level.DEBUG.toString().toLowerCase();
     private static final String INFO = org.slf4j.event.Level.INFO.toString().toLowerCase();
 
+    private static final String EMAIL_INFO_LOG_MESSAGE = "Consuming email record with sender reference: email-ref-123";
+    private static final String EMAIL_DEBUG_LOG_MESSAGE = "Consuming email record: ";
+    private static final String EMAIL_ERROR_LOG_MESSAGE = "Failed to send email request to integration API";
+
+    private static final String LETTER_INFO_LOG_MESSAGE = "Consuming letter record with sender reference: letter-ref-456";
+    private static final String LETTER_DEBUG_LOG_MESSAGE = "Consuming letter record: ";
+    private static final String LETTER_ERROR_LOG_MESSAGE = "Failed to send letter request to integration API";
+
+
     @BeforeEach
     void setUp() {
         mockEmailNotification = new ChsEmailNotification();
@@ -98,8 +107,7 @@ class KafkaConsumerServiceTest {
                     "Consuming email record: " + emailRecord);
             assertEmailCommonFields(debugData);
 
-            var infoData = getDataFromLogMessage(outputCapture, INFO,
-                    "Consuming email record with sender reference: email-ref-123");
+            var infoData = getDataFromLogMessage(outputCapture, INFO, EMAIL_INFO_LOG_MESSAGE);
             assertEmailCommonFields(infoData);
 
         }
@@ -122,12 +130,10 @@ class KafkaConsumerServiceTest {
             // When
             kafkaConsumerService.consumeLetterMessage(letterRecord, acknowledgment);
 
-            var debugData = getDataFromLogMessage(outputCapture, DEBUG,
-                    "Consuming letter record: " + letterRecord);
+            var debugData = getDataFromLogMessage(outputCapture, DEBUG, LETTER_DEBUG_LOG_MESSAGE + letterRecord);
             assertLetterCommonFields(debugData);
 
-            var infoData = getDataFromLogMessage(outputCapture, INFO,
-                    "Consuming letter record with sender reference: letter-ref-456");
+            var infoData = getDataFromLogMessage(outputCapture, INFO, LETTER_INFO_LOG_MESSAGE);
             assertLetterCommonFields(infoData);
 
         }
@@ -155,8 +161,7 @@ class KafkaConsumerServiceTest {
                     "Consuming email record: " + emailRecord);
             assertEmailCommonFields(debugData);
 
-            var infoData = getDataFromLogMessage(outputCapture, INFO,
-                    "Consuming email record with sender reference: email-ref-123");
+            var infoData = getDataFromLogMessage(outputCapture, INFO, EMAIL_INFO_LOG_MESSAGE);
             assertEmailCommonFields(infoData);
 
             assertEquals(0, outputCapture.findAmountByEvent(ERROR),
@@ -183,12 +188,10 @@ class KafkaConsumerServiceTest {
             assertThrows(RuntimeException.class,
                     () -> kafkaConsumerService.consumeLetterMessage(letterRecord, acknowledgment));
 
-            var debugData = getDataFromLogMessage(outputCapture, DEBUG,
-                    "Consuming letter record: " + letterRecord);
+            var debugData = getDataFromLogMessage(outputCapture, DEBUG, LETTER_DEBUG_LOG_MESSAGE + letterRecord);
             assertLetterCommonFields(debugData);
 
-            var infoData = getDataFromLogMessage(outputCapture, INFO,
-                    "Consuming letter record with sender reference: letter-ref-456");
+            var infoData = getDataFromLogMessage(outputCapture, INFO, LETTER_INFO_LOG_MESSAGE);
             assertLetterCommonFields(infoData);
         }
 
@@ -217,12 +220,10 @@ class KafkaConsumerServiceTest {
                     "Consuming email record: " + emailRecord);
             assertEmailCommonFields(debugData);
 
-            var infoData = getDataFromLogMessage(outputCapture, INFO,
-                    "Consuming email record with sender reference: email-ref-123");
+            var infoData = getDataFromLogMessage(outputCapture, INFO, EMAIL_INFO_LOG_MESSAGE);
             assertEmailCommonFields(infoData);
 
-            var errorData = getDataFromLogMessage(outputCapture, ERROR,
-                    "Failed to send email request to integration API");
+            var errorData = getDataFromLogMessage(outputCapture, ERROR, EMAIL_ERROR_LOG_MESSAGE);
             assertJsonHasAndEquals(errorData, "error_message", "API failed");
             assertEmailCommonFields(errorData);
 
@@ -275,12 +276,10 @@ class KafkaConsumerServiceTest {
                     "Consuming email record: " + emailRecord);
             assertEmailCommonFields(debugData);
 
-            var infoData = getDataFromLogMessage(outputCapture, INFO,
-                    "Consuming email record with sender reference: email-ref-123");
+            var infoData = getDataFromLogMessage(outputCapture, INFO, EMAIL_INFO_LOG_MESSAGE);
             assertEmailCommonFields(infoData);
 
-            var errorData = getDataFromLogMessage(outputCapture, ERROR,
-                    "Failed to send email request to integration API");
+            var errorData = getDataFromLogMessage(outputCapture, ERROR, EMAIL_ERROR_LOG_MESSAGE);
             assertJsonHasAndEquals(errorData, "error_message", "First attempt failed");
             assertEmailCommonFields(errorData);
 
@@ -299,8 +298,7 @@ class KafkaConsumerServiceTest {
                     "Consuming email record: " + emailRecord);
             assertEmailCommonFields(debugData);
 
-            var infoData = getDataFromLogMessage(outputCapture, INFO,
-                    "Consuming email record with sender reference: email-ref-123");
+            var infoData = getDataFromLogMessage(outputCapture, INFO, EMAIL_INFO_LOG_MESSAGE);
             assertEmailCommonFields(infoData);
         }
         // Then - Verify the retry succeeded and was acknowledged
@@ -329,12 +327,10 @@ class KafkaConsumerServiceTest {
                     () -> spyKafkaConsumerService.consumeLetterMessage(letterRecord,
                             acknowledgment));
 
-            var debugData = getDataFromLogMessage(outputCapture, DEBUG,
-                    "Consuming letter record: " + letterRecord);
+            var debugData = getDataFromLogMessage(outputCapture, DEBUG, LETTER_DEBUG_LOG_MESSAGE + letterRecord);
             assertLetterCommonFields(debugData);
 
-            var infoData = getDataFromLogMessage(outputCapture, INFO,
-                    "Consuming letter record with sender reference: letter-ref-456");
+            var infoData = getDataFromLogMessage(outputCapture, INFO, LETTER_INFO_LOG_MESSAGE);
             assertLetterCommonFields(infoData);
 
             var errorData = getDataFromLogMessage(outputCapture, ERROR,
@@ -353,13 +349,11 @@ class KafkaConsumerServiceTest {
         try (var outputCapture = new OutputCapture()) {
             spyKafkaConsumerService.consumeLetterMessage(letterRecord, acknowledgment);
 
-            var debugData = getDataFromLogMessage(outputCapture, DEBUG,
-                    "Consuming letter record: " + letterRecord);
+            var debugData = getDataFromLogMessage(outputCapture, DEBUG, LETTER_DEBUG_LOG_MESSAGE + letterRecord);
             assertLetterCommonFields(debugData);
 
             // Test Info Log Message
-            getDataFromLogMessage(outputCapture, INFO,
-                    "Consuming letter record with sender reference: letter-ref-456");
+            getDataFromLogMessage(outputCapture, INFO, LETTER_INFO_LOG_MESSAGE);
 
         }
 
@@ -371,7 +365,7 @@ class KafkaConsumerServiceTest {
     }
 
     @Test
-    void When_NonRetryableErrorOccurs_Expect_ExceptionPropagated() throws IOException {
+    void When_Email_NonRetryableErrorOccurs_Expect_ExceptionPropagated() throws IOException {
         // Given
         NonRetryableErrorException nonRetryableError = new NonRetryableErrorException(
                 "Do not retry this error");
@@ -386,18 +380,16 @@ class KafkaConsumerServiceTest {
                     () -> kafkaConsumerService.consumeEmailMessage(emailRecord, acknowledgment));
 
             // Test Info Log Message
-            var infoData = getDataFromLogMessage(outputCapture, INFO,
-                    "Consuming email record with sender reference: email-ref-123");
+            var infoData = getDataFromLogMessage(outputCapture, INFO, EMAIL_INFO_LOG_MESSAGE);
             assertEmailCommonFields(infoData);
 
             // Test Error Log Message
-            var errorData = getDataFromLogMessage(outputCapture, ERROR,
-                    "Failed to send email request to integration API");
+            var errorData = getDataFromLogMessage(outputCapture, ERROR, EMAIL_ERROR_LOG_MESSAGE);
             assertEmailCommonFields(errorData);
 
             // Test Debug Log Message
             var debugData = getDataFromLogMessage(outputCapture, DEBUG,
-"Consuming email record: " + emailRecord);
+                    "Consuming email record: " + emailRecord);
             assertEmailCommonFields(debugData);
 
         }
@@ -405,6 +397,41 @@ class KafkaConsumerServiceTest {
         // Then
         verify(messageMapper).mapToEmailDetailsRequest(mockEmailNotification);
         verify(notifyIntegrationService).sendEmailMessageToIntegrationApi(mockEmailRequest);
+        verifyNoInteractions(acknowledgment);
+    }
+
+    @Test
+    void When_Letter_NonRetryableErrorOccurs_Expect_ExceptionPropagated() throws IOException {
+        // Given
+        NonRetryableErrorException nonRetryableError = new NonRetryableErrorException(
+                "Do not retry this error");
+        when(messageMapper.mapToLetterDetailsRequest(mockLetterNotification)).thenReturn(
+                mockLetterRequest);
+        when(notifyIntegrationService.sendLetterMessageToIntegrationApi(
+                mockLetterRequest)).thenReturn(Mono.error(nonRetryableError));
+
+        try (var outputCapture = new OutputCapture()) {
+            // When/Then - Exception should propagate without retry
+            assertThrows(NonRetryableErrorException.class,
+                    () -> kafkaConsumerService.consumeLetterMessage(letterRecord, acknowledgment));
+
+            // Test Info Log Message
+            var infoData = getDataFromLogMessage(outputCapture, INFO, LETTER_INFO_LOG_MESSAGE);
+            assertLetterCommonFields(infoData);
+
+            // Test Error Log Message
+            var errorData = getDataFromLogMessage(outputCapture, ERROR, LETTER_ERROR_LOG_MESSAGE);
+            assertLetterCommonFields(errorData);
+
+            // Test Debug Log Message
+            var debugData = getDataFromLogMessage(outputCapture, DEBUG, LETTER_DEBUG_LOG_MESSAGE + letterRecord);
+            assertLetterCommonFields(debugData);
+
+        }
+
+        // Then
+        verify(messageMapper).mapToLetterDetailsRequest(mockLetterNotification);
+        verify(notifyIntegrationService).sendLetterMessageToIntegrationApi(mockLetterRequest);
         verifyNoInteractions(acknowledgment);
     }
 

--- a/src/test/java/uk/gov/companieshouse/chs/notification/kafka/consumer/kafkaintegration/KafkaConsumerServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/chs/notification/kafka/consumer/kafkaintegration/KafkaConsumerServiceTest.java
@@ -19,6 +19,7 @@ import uk.gov.companieshouse.api.chs.notification.model.GovUkEmailDetailsRequest
 import uk.gov.companieshouse.api.chs.notification.model.GovUkLetterDetailsRequest;
 import uk.gov.companieshouse.chs.notification.kafka.consumer.apiintegration.NotifyIntegrationService;
 import uk.gov.companieshouse.chs.notification.kafka.consumer.translator.MessageMapper;
+import uk.gov.companieshouse.logging.EventType;
 import uk.gov.companieshouse.notification.ChsEmailNotification;
 import uk.gov.companieshouse.notification.ChsLetterNotification;
 import uk.gov.companieshouse.notification.SenderDetails;
@@ -58,13 +59,8 @@ class KafkaConsumerServiceTest {
     private GovUkLetterDetailsRequest mockLetterRequest;
     private ConsumerRecord<String, ChsEmailNotification> emailRecord;
     private ConsumerRecord<String, ChsLetterNotification> letterRecord;
-
-    private static final String ERROR = org.slf4j.event.Level.ERROR.toString().toLowerCase();
-    private static final String DEBUG = org.slf4j.event.Level.DEBUG.toString().toLowerCase();
-    private static final String INFO = org.slf4j.event.Level.INFO.toString().toLowerCase();
-
+    
     private static final String EMAIL_INFO_LOG_MESSAGE = "Consuming email record with sender reference: email-ref-123";
-    private static final String EMAIL_DEBUG_LOG_MESSAGE = "Consuming email record: ";
     private static final String EMAIL_ERROR_LOG_MESSAGE = "Failed to send email request to integration API";
 
     private static final String LETTER_INFO_LOG_MESSAGE = "Consuming letter record with sender reference: letter-ref-456";
@@ -103,11 +99,11 @@ class KafkaConsumerServiceTest {
             // When
             kafkaConsumerService.consumeEmailMessage(emailRecord, acknowledgment);
 
-            var debugData = getDataFromLogMessage(outputCapture, DEBUG,
+            var debugData = getDataFromLogMessage(outputCapture, EventType.DEBUG,
                     "Consuming email record: " + emailRecord);
             assertEmailCommonFields(debugData);
 
-            var infoData = getDataFromLogMessage(outputCapture, INFO, EMAIL_INFO_LOG_MESSAGE);
+            var infoData = getDataFromLogMessage(outputCapture, EventType.INFO, EMAIL_INFO_LOG_MESSAGE);
             assertEmailCommonFields(infoData);
 
         }
@@ -130,10 +126,10 @@ class KafkaConsumerServiceTest {
             // When
             kafkaConsumerService.consumeLetterMessage(letterRecord, acknowledgment);
 
-            var debugData = getDataFromLogMessage(outputCapture, DEBUG, LETTER_DEBUG_LOG_MESSAGE + letterRecord);
+            var debugData = getDataFromLogMessage(outputCapture, EventType.DEBUG, LETTER_DEBUG_LOG_MESSAGE + letterRecord);
             assertLetterCommonFields(debugData);
 
-            var infoData = getDataFromLogMessage(outputCapture, INFO, LETTER_INFO_LOG_MESSAGE);
+            var infoData = getDataFromLogMessage(outputCapture, EventType.INFO, LETTER_INFO_LOG_MESSAGE);
             assertLetterCommonFields(infoData);
 
         }
@@ -157,14 +153,14 @@ class KafkaConsumerServiceTest {
             assertThrows(RuntimeException.class,
                     () -> kafkaConsumerService.consumeEmailMessage(emailRecord, acknowledgment));
 
-            var debugData = getDataFromLogMessage(outputCapture, DEBUG,
+            var debugData = getDataFromLogMessage(outputCapture, EventType.DEBUG,
                     "Consuming email record: " + emailRecord);
             assertEmailCommonFields(debugData);
 
-            var infoData = getDataFromLogMessage(outputCapture, INFO, EMAIL_INFO_LOG_MESSAGE);
+            var infoData = getDataFromLogMessage(outputCapture, EventType.INFO, EMAIL_INFO_LOG_MESSAGE);
             assertEmailCommonFields(infoData);
 
-            assertEquals(0, outputCapture.findAmountByEvent(ERROR),
+            assertEquals(0, outputCapture.findAmountByEvent(EventType.ERROR),
                     "No error logs should be generated for mapping failure");
 
         }
@@ -188,10 +184,10 @@ class KafkaConsumerServiceTest {
             assertThrows(RuntimeException.class,
                     () -> kafkaConsumerService.consumeLetterMessage(letterRecord, acknowledgment));
 
-            var debugData = getDataFromLogMessage(outputCapture, DEBUG, LETTER_DEBUG_LOG_MESSAGE + letterRecord);
+            var debugData = getDataFromLogMessage(outputCapture, EventType.DEBUG, LETTER_DEBUG_LOG_MESSAGE + letterRecord);
             assertLetterCommonFields(debugData);
 
-            var infoData = getDataFromLogMessage(outputCapture, INFO, LETTER_INFO_LOG_MESSAGE);
+            var infoData = getDataFromLogMessage(outputCapture, EventType.INFO, LETTER_INFO_LOG_MESSAGE);
             assertLetterCommonFields(infoData);
         }
 
@@ -216,14 +212,14 @@ class KafkaConsumerServiceTest {
             assertThrows(RuntimeException.class,
                     () -> kafkaConsumerService.consumeEmailMessage(emailRecord, acknowledgment));
 
-            var debugData = getDataFromLogMessage(outputCapture, DEBUG,
+            var debugData = getDataFromLogMessage(outputCapture, EventType.DEBUG,
                     "Consuming email record: " + emailRecord);
             assertEmailCommonFields(debugData);
 
-            var infoData = getDataFromLogMessage(outputCapture, INFO, EMAIL_INFO_LOG_MESSAGE);
+            var infoData = getDataFromLogMessage(outputCapture, EventType.INFO, EMAIL_INFO_LOG_MESSAGE);
             assertEmailCommonFields(infoData);
 
-            var errorData = getDataFromLogMessage(outputCapture, ERROR, EMAIL_ERROR_LOG_MESSAGE);
+            var errorData = getDataFromLogMessage(outputCapture, EventType.ERROR, EMAIL_ERROR_LOG_MESSAGE);
             assertJsonHasAndEquals(errorData, "error_message", "API failed");
             assertEmailCommonFields(errorData);
 
@@ -272,14 +268,14 @@ class KafkaConsumerServiceTest {
             assertThrows(RuntimeException.class,
                     () -> spyKafkaConsumerService.consumeEmailMessage(emailRecord, acknowledgment));
 
-            var debugData = getDataFromLogMessage(outputCapture, DEBUG,
+            var debugData = getDataFromLogMessage(outputCapture, EventType.DEBUG,
                     "Consuming email record: " + emailRecord);
             assertEmailCommonFields(debugData);
 
-            var infoData = getDataFromLogMessage(outputCapture, INFO, EMAIL_INFO_LOG_MESSAGE);
+            var infoData = getDataFromLogMessage(outputCapture, EventType.INFO, EMAIL_INFO_LOG_MESSAGE);
             assertEmailCommonFields(infoData);
 
-            var errorData = getDataFromLogMessage(outputCapture, ERROR, EMAIL_ERROR_LOG_MESSAGE);
+            var errorData = getDataFromLogMessage(outputCapture, EventType.ERROR, EMAIL_ERROR_LOG_MESSAGE);
             assertJsonHasAndEquals(errorData, "error_message", "First attempt failed");
             assertEmailCommonFields(errorData);
 
@@ -294,11 +290,11 @@ class KafkaConsumerServiceTest {
             // When - Second call should succeed
             spyKafkaConsumerService.consumeEmailMessage(emailRecord, acknowledgment);
 
-            var debugData = getDataFromLogMessage(outputCapture, DEBUG,
+            var debugData = getDataFromLogMessage(outputCapture, EventType.DEBUG,
                     "Consuming email record: " + emailRecord);
             assertEmailCommonFields(debugData);
 
-            var infoData = getDataFromLogMessage(outputCapture, INFO, EMAIL_INFO_LOG_MESSAGE);
+            var infoData = getDataFromLogMessage(outputCapture, EventType.INFO, EMAIL_INFO_LOG_MESSAGE);
             assertEmailCommonFields(infoData);
         }
         // Then - Verify the retry succeeded and was acknowledged
@@ -327,13 +323,13 @@ class KafkaConsumerServiceTest {
                     () -> spyKafkaConsumerService.consumeLetterMessage(letterRecord,
                             acknowledgment));
 
-            var debugData = getDataFromLogMessage(outputCapture, DEBUG, LETTER_DEBUG_LOG_MESSAGE + letterRecord);
+            var debugData = getDataFromLogMessage(outputCapture, EventType.DEBUG, LETTER_DEBUG_LOG_MESSAGE + letterRecord);
             assertLetterCommonFields(debugData);
 
-            var infoData = getDataFromLogMessage(outputCapture, INFO, LETTER_INFO_LOG_MESSAGE);
+            var infoData = getDataFromLogMessage(outputCapture, EventType.INFO, LETTER_INFO_LOG_MESSAGE);
             assertLetterCommonFields(infoData);
 
-            var errorData = getDataFromLogMessage(outputCapture, ERROR,
+            var errorData = getDataFromLogMessage(outputCapture, EventType.ERROR,
                     "Failed to send letter request to integration API");
             assertJsonHasAndEquals(errorData, "error_message", "First attempt failed");
             assertLetterCommonFields(errorData);
@@ -349,11 +345,11 @@ class KafkaConsumerServiceTest {
         try (var outputCapture = new OutputCapture()) {
             spyKafkaConsumerService.consumeLetterMessage(letterRecord, acknowledgment);
 
-            var debugData = getDataFromLogMessage(outputCapture, DEBUG, LETTER_DEBUG_LOG_MESSAGE + letterRecord);
+            var debugData = getDataFromLogMessage(outputCapture, EventType.DEBUG, LETTER_DEBUG_LOG_MESSAGE + letterRecord);
             assertLetterCommonFields(debugData);
 
             // Test Info Log Message
-            getDataFromLogMessage(outputCapture, INFO, LETTER_INFO_LOG_MESSAGE);
+            getDataFromLogMessage(outputCapture, EventType.INFO, LETTER_INFO_LOG_MESSAGE);
 
         }
 
@@ -380,15 +376,15 @@ class KafkaConsumerServiceTest {
                     () -> kafkaConsumerService.consumeEmailMessage(emailRecord, acknowledgment));
 
             // Test Info Log Message
-            var infoData = getDataFromLogMessage(outputCapture, INFO, EMAIL_INFO_LOG_MESSAGE);
+            var infoData = getDataFromLogMessage(outputCapture, EventType.INFO, EMAIL_INFO_LOG_MESSAGE);
             assertEmailCommonFields(infoData);
 
             // Test Error Log Message
-            var errorData = getDataFromLogMessage(outputCapture, ERROR, EMAIL_ERROR_LOG_MESSAGE);
+            var errorData = getDataFromLogMessage(outputCapture, EventType.ERROR, EMAIL_ERROR_LOG_MESSAGE);
             assertEmailCommonFields(errorData);
 
             // Test Debug Log Message
-            var debugData = getDataFromLogMessage(outputCapture, DEBUG,
+            var debugData = getDataFromLogMessage(outputCapture, EventType.DEBUG,
                     "Consuming email record: " + emailRecord);
             assertEmailCommonFields(debugData);
 
@@ -416,15 +412,15 @@ class KafkaConsumerServiceTest {
                     () -> kafkaConsumerService.consumeLetterMessage(letterRecord, acknowledgment));
 
             // Test Info Log Message
-            var infoData = getDataFromLogMessage(outputCapture, INFO, LETTER_INFO_LOG_MESSAGE);
+            var infoData = getDataFromLogMessage(outputCapture, EventType.INFO, LETTER_INFO_LOG_MESSAGE);
             assertLetterCommonFields(infoData);
 
             // Test Error Log Message
-            var errorData = getDataFromLogMessage(outputCapture, ERROR, LETTER_ERROR_LOG_MESSAGE);
+            var errorData = getDataFromLogMessage(outputCapture, EventType.ERROR, LETTER_ERROR_LOG_MESSAGE);
             assertLetterCommonFields(errorData);
 
             // Test Debug Log Message
-            var debugData = getDataFromLogMessage(outputCapture, DEBUG, LETTER_DEBUG_LOG_MESSAGE + letterRecord);
+            var debugData = getDataFromLogMessage(outputCapture,EventType.DEBUG, LETTER_DEBUG_LOG_MESSAGE + letterRecord);
             assertLetterCommonFields(debugData);
 
         }


### PR DESCRIPTION
__JIRA Ticket Number__
[DEEP-296](https://companieshouse.atlassian.net/browse/DEEP-296)

__Short description outlining key changes/additions__

I have added a `Map` created by `DataMap` to the logs already present in `KafkaConsumerService`.

I have also added logging in `NotifyIntegrationService` in case of an error though I can also add logging on success and when it is triggered if need be.

I have also added testing into the tests that have already been created. This is done via capturing the standard out similar to what is done to test logging in the overseas-entities-api, however here output will also still be displayed to the user.

### Type of change

* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [x] I have added unit tests for new code that I have added
* [x] I have added/updated functional tests where appropriate
* [x] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__

[DEEP-296]: https://companieshouse.atlassian.net/browse/DEEP-296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ